### PR TITLE
Fix image generation handler to use existing OpenAI method

### DIFF
--- a/enkibot/core/intent_handlers/image_generation_handler.py
+++ b/enkibot/core/intent_handlers/image_generation_handler.py
@@ -89,12 +89,12 @@ class ImageGenerationIntentHandler:
             return
 
         try:
-            generated_images_data = await self.llm_services.generate_image_with_dalle(
+            generated_images_data = await self.llm_services.generate_image_openai(
                 prompt=clean_prompt,
-                n=config.DEFAULT_IMAGE_N,        
-                size=config.DEFAULT_IMAGE_SIZE,  
-                quality=config.DEFAULT_IMAGE_QUALITY, 
-                response_format="url" 
+                n=config.DEFAULT_IMAGE_N,
+                size=config.DEFAULT_IMAGE_SIZE,
+                quality=config.DEFAULT_IMAGE_QUALITY,
+                response_format="url"
             )
             
             await context.bot.delete_message(chat_id=update.effective_chat.id, message_id=preliminary_reply.message_id)


### PR DESCRIPTION
## Summary
- Call `generate_image_openai` in the image generation handler instead of the non-existent `generate_image_with_dalle` method.

## Testing
- `python -m py_compile enkibot/core/intent_handlers/image_generation_handler.py`
- `pytest`
- `python - <<'PY' ... generate_image_openai('a cat in space') ... PY`

------
https://chatgpt.com/codex/tasks/task_e_6895fddfcbc8832a8ea6f2c469058a8d