### PR TITLE
Remove stray BOM in telegram handlers

### DIFF
--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -4,7 +4,7 @@
 # - Enhance error handling and logging for better maintenance.
 # - Expand unit tests to cover more edge cases.
 # -------------------------------------------------------------------------------
-﻿# enkibot/core/telegram_handlers.py
+# enkibot/core/telegram_handlers.py
 # EnkiBot: Advanced Multilingual Telegram AI Assistant
 # Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
 # (Your GPLv3 Header)


### PR DESCRIPTION
## Summary
- remove stray UTF-8 BOM character from `telegram_handlers.py` causing SyntaxError at runtime

## Testing
- `python -m enkibot.main` *(fails: ModuleNotFoundError: No module named 'telegram')*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896160e1ffc832aa1b5c7e092f6fa29