### PR TITLE
Remove stray BOM causing syntax error in telegram handlers

### DIFF
--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -4,7 +4,7 @@
 # - Enhance error handling and logging for better maintenance.
 # - Expand unit tests to cover more edge cases.
 # -------------------------------------------------------------------------------
-﻿# enkibot/core/telegram_handlers.py
+# enkibot/core/telegram_handlers.py
 # EnkiBot: Advanced Multilingual Telegram AI Assistant
 # Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
 # (Your GPLv3 Header)


### PR DESCRIPTION
## Summary
- remove an unexpected byte-order mark from `telegram_handlers.py` that prevented module import

## Testing
- `python -m pytest`
- `python -m enkibot.main` *(fails: ModuleNotFoundError: No module named 'telegram')*


------
https://chatgpt.com/codex/tasks/task_e_68963d253ab8832aa2c977685563c6da