### PR TITLE
Increase Telegram request timeout

### DIFF
--- a/enkibot/config.py
+++ b/enkibot/config.py
@@ -35,6 +35,10 @@ TELEGRAM_BOT_TOKEN = os.getenv('ENKI_BOT_TOKEN')
 # A list of bot nicknames that trigger a response in group chats.
 BOT_NICKNAMES_TO_CHECK = ["enki", "enkibot", "энки", "энкибот", "бот", "bot"]
 
+# Timeout settings for Telegram HTTP requests (in seconds).
+TELEGRAM_CONNECT_TIMEOUT = float(os.getenv('ENKI_BOT_TELEGRAM_CONNECT_TIMEOUT', '30'))
+TELEGRAM_READ_TIMEOUT = float(os.getenv('ENKI_BOT_TELEGRAM_READ_TIMEOUT', '30'))
+
 # --- Database Configuration (MS SQL Server) ---
 SQL_SERVER_NAME = os.getenv('ENKI_BOT_SQL_SERVER_NAME')
 SQL_DATABASE_NAME = os.getenv('ENKI_BOT_SQL_DATABASE_NAME')

--- a/enkibot/main.py
+++ b/enkibot/main.py
@@ -25,8 +25,10 @@ import os
 import logging
 import asyncio
 from typing import Optional 
-from telegram import Update 
-from telegram.ext import Application 
+from telegram import Update
+from telegram.ext import Application
+from telegram.request import HTTPXRequest
+import httpx
 
 from enkibot import config
 from enkibot.utils.logging_config import setup_logging
@@ -58,7 +60,15 @@ def main() -> None:
 
     try:
         logger.info("Initializing Telegram PTB Application...")
-        ptb_app = Application.builder().token(config.TELEGRAM_BOT_TOKEN).build()
+        request = HTTPXRequest(
+            httpx.AsyncClient(
+                timeout=httpx.Timeout(
+                    config.TELEGRAM_CONNECT_TIMEOUT,
+                    read=config.TELEGRAM_READ_TIMEOUT,
+                )
+            )
+        )
+        ptb_app = Application.builder().token(config.TELEGRAM_BOT_TOKEN).request(request).build()
         
         logger.info("Initializing EnkiBotApplication...")
         # --- MODIFIED BOT INSTANTIATION ---


### PR DESCRIPTION
## Summary
- make Telegram HTTP timeout configurable and set default to 30s
- build Application with custom HTTPXRequest that uses the new timeouts

## Testing
- `pytest`
- `python -m py_compile enkibot/config.py enkibot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_689779b747c0832aaa0b1f32b11899b8