### PR TITLE
Fix HTTPXRequest AsyncClient initialization

### DIFF
--- a/enkibot/main.py
+++ b/enkibot/main.py
@@ -61,9 +61,9 @@ def main() -> None:
     try:
         logger.info("Initializing Telegram PTB Application...")
         request = HTTPXRequest(
-            httpx.AsyncClient(
+            client=httpx.AsyncClient(
                 timeout=httpx.Timeout(
-                    config.TELEGRAM_CONNECT_TIMEOUT,
+                    connect=config.TELEGRAM_CONNECT_TIMEOUT,
                     read=config.TELEGRAM_READ_TIMEOUT,
                 )
             )


### PR DESCRIPTION
## Summary
- Pass `AsyncClient` as a named `client` argument when creating `HTTPXRequest`
- Explicitly set timeout's `connect` and `read` values

## Testing
- `python -m py_compile enkibot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_68977c4ea5cc832a9812e3d4833f32e8