### PR TITLE
feat: add local model router and web/rag tools

### DIFF
--- a/enkibot/local_telegram_bot.py
+++ b/enkibot/local_telegram_bot.py
@@ -1,0 +1,102 @@
+# enkibot/local_telegram_bot.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------------
+# Future Improvements:
+# - Improve modularity to support additional features and services.
+# - Enhance error handling and logging for better maintenance.
+# - Expand unit tests to cover more edge cases.
+# -------------------------------------------------------------------------------
+"""Minimal Telegram wiring for the local two‑tier model setup.
+
+This script bypasses the project's main application stack to present a compact
+example of running EnkiBot purely with local models.  It exposes three
+commands:
+
+``/fast`` – use the 7–8B model directly.
+``/deep`` – force the 70B/72B model.
+``/web``  – perform a duckduckgo search, fetch top pages and summarise with
+            citations via the fast model.
+
+Any other message goes through :class:`~enkibot.modules.model_router.ModelRouter`
+which escalates to the deep model when needed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+from telegram.ext import ApplicationBuilder, CommandHandler, MessageHandler, filters
+
+from .modules.local_model_manager import LocalModelManager, ModelConfig
+from .modules.model_router import ModelRouter
+from .modules.web_tool import web_research
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+FAST_MODEL_PATH = os.getenv("ENKIBOT_FAST_MODEL", "mistral-7b-instruct.Q5_K_M.gguf")
+DEEP_MODEL_PATH = os.getenv("ENKIBOT_DEEP_MODEL", "llama-3-70b-instruct.Q4_K_M.gguf")
+
+manager = LocalModelManager(
+    ModelConfig(FAST_MODEL_PATH, n_ctx=4096, n_threads=16),
+    ModelConfig(DEEP_MODEL_PATH, n_ctx=8192, n_threads=16),
+)
+router = ModelRouter(manager)
+
+
+async def fast_cmd(update, context):  # /fast
+    prompt = " ".join(context.args)
+    await update.message.reply_text(manager.generate(prompt, model="fast"))
+
+
+async def deep_cmd(update, context):  # /deep
+    prompt = " ".join(context.args)
+    await update.message.reply_text(manager.generate(prompt, model="deep"))
+
+
+async def web_cmd(update, context):  # /web query
+    query = " ".join(context.args)
+    docs = web_research(query, k=3)
+    context_block = "\n\n".join(
+        f"[{i+1}] {d['title']}\n{d['text'][:500]}" for i, d in enumerate(docs)
+    )
+    prompt = (
+        f"Use the following web results to answer the question. Cite sources "
+        f"as [number](url).\n\n{context_block}\n\nQuestion: {query}"
+    )
+    answer = manager.generate(prompt, model="fast")
+    await update.message.reply_text(answer)
+
+
+async def default_handler(update, context):
+    response = router.generate(update.message.text)
+    await update.message.reply_text(response)
+
+
+def main() -> None:
+    token = os.environ["TELEGRAM_BOT_TOKEN"]
+    app = ApplicationBuilder().token(token).build()
+    app.add_handler(CommandHandler("fast", fast_cmd))
+    app.add_handler(CommandHandler("deep", deep_cmd))
+    app.add_handler(CommandHandler("web", web_cmd))
+    app.add_handler(MessageHandler(filters.TEXT & ~filters.COMMAND, default_handler))
+    logger.info("Starting local EnkiBot")
+    app.run_polling()
+
+
+if __name__ == "__main__":
+    main()

--- a/enkibot/modules/local_model_manager.py
+++ b/enkibot/modules/local_model_manager.py
@@ -1,0 +1,131 @@
+# enkibot/modules/local_model_manager.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------------
+# Future Improvements:
+# - Improve modularity to support additional features and services.
+# - Enhance error handling and logging for better maintenance.
+# - Expand unit tests to cover more edge cases.
+# -------------------------------------------------------------------------------
+"""Thin wrapper around :mod:`llama_cpp` for loading local models.
+
+The project historically relied on hosted LLM providers.  For users who want
+fully local inference we provide :class:`LocalModelManager` which manages two
+GGUF models – a *fast* one (7B/8B) and a *deep* one (70B/72B).  Both models are
+loaded lazily to keep start‑up time low and to conserve memory.
+
+Example
+-------
+>>> from enkibot.modules.local_model_manager import LocalModelManager
+>>> manager = LocalModelManager(
+...     fast_model_path="mistral-7b-instruct.Q5_K_M.gguf",
+...     deep_model_path="llama-3-70b-instruct.Q4_K_M.gguf",
+... )
+>>> text = manager.generate("Write a haiku about modular bots", model="fast")
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+import logging
+
+try:  # llama_cpp is an optional dependency
+    from llama_cpp import Llama
+except Exception:  # pragma: no cover - library not always available in CI
+    Llama = None  # type: ignore
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ModelConfig:
+    """Configuration for a single local model."""
+
+    model_path: str
+    n_ctx: int = 4096
+    n_threads: int = 8
+
+
+class LocalModelManager:
+    """Load and run local GGUF models via :mod:`llama_cpp`.
+
+    Parameters
+    ----------
+    fast_model_cfg:
+        Configuration for the smaller, faster model (e.g. Mistral‑7B or
+        Llama‑3‑8B).
+    deep_model_cfg:
+        Configuration for the larger, higher quality model (e.g. Llama‑3‑70B or
+        Qwen‑2‑72B).
+    """
+
+    def __init__(self, fast_model_cfg: ModelConfig, deep_model_cfg: ModelConfig):
+        self.fast_cfg = fast_model_cfg
+        self.deep_cfg = deep_model_cfg
+        self._fast: Optional[Llama] = None
+        self._deep: Optional[Llama] = None
+
+    # ------------------------------------------------------------------
+    # Loading helpers
+    def _load_fast(self) -> Llama:
+        if self._fast is None:
+            if Llama is None:
+                raise RuntimeError("llama_cpp is not installed")
+            logger.info("Loading fast model from %s", self.fast_cfg.model_path)
+            self._fast = Llama(
+                model_path=self.fast_cfg.model_path,
+                n_ctx=self.fast_cfg.n_ctx,
+                n_threads=self.fast_cfg.n_threads,
+            )
+        return self._fast
+
+    def _load_deep(self) -> Llama:
+        if self._deep is None:
+            if Llama is None:
+                raise RuntimeError("llama_cpp is not installed")
+            logger.info("Loading deep model from %s", self.deep_cfg.model_path)
+            self._deep = Llama(
+                model_path=self.deep_cfg.model_path,
+                n_ctx=self.deep_cfg.n_ctx,
+                n_threads=self.deep_cfg.n_threads,
+            )
+        return self._deep
+
+    # ------------------------------------------------------------------
+    # Public API
+    def generate(self, prompt: str, model: str = "fast", max_tokens: int = 512,
+                 temperature: float = 0.7) -> str:
+        """Generate text using the requested model.
+
+        Parameters
+        ----------
+        prompt:
+            User prompt.
+        model:
+            ``"fast"`` or ``"deep"``.
+        max_tokens, temperature:
+            Passed to :class:`llama_cpp.Llama`.
+        """
+
+        llm = self._load_fast() if model == "fast" else self._load_deep()
+        template = f"<<SYS>>You are a helpful assistant.<</SYS>>\n[INST]{prompt}[/INST]"
+        result = llm(
+            template,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            stop=["</s>"],
+        )
+        return result["choices"][0]["text"]

--- a/enkibot/modules/model_router.py
+++ b/enkibot/modules/model_router.py
@@ -1,0 +1,72 @@
+# enkibot/modules/model_router.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------------
+# Future Improvements:
+# - Improve modularity to support additional features and services.
+# - Enhance error handling and logging for better maintenance.
+# - Expand unit tests to cover more edge cases.
+# -------------------------------------------------------------------------------
+"""Routing logic for selecting between fast and deep local models."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+import logging
+import re
+
+from .local_model_manager import LocalModelManager
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RoutingDecision:
+    model: str
+    clean_prompt: str
+    use_web: bool = False
+
+
+class ModelRouter:
+    """Simple heuristic router for two‑tier local models."""
+
+    def __init__(self, manager: LocalModelManager):
+        self.manager = manager
+
+    # ------------------------------------------------------------------
+    def _needs_deep_model(self, prompt: str) -> bool:
+        if prompt.startswith("/deep"):
+            return True
+        if len(prompt) > 400 or len(prompt.split()) > 120:
+            return True
+        return False
+
+    def _needs_web(self, prompt: str) -> bool:
+        triggers = ["http://", "https://", "www", "today", "current", "latest"]
+        lowered = prompt.lower()
+        return any(t in lowered for t in triggers) or prompt.startswith("/web")
+
+    def route(self, prompt: str) -> RoutingDecision:
+        use_web = self._needs_web(prompt)
+        model = "deep" if self._needs_deep_model(prompt) else "fast"
+        clean = re.sub(r"^/(deep|fast|web)\s*", "", prompt).strip()
+        logger.debug("Routing prompt to %s model (web=%s)", model, use_web)
+        return RoutingDecision(model=model, clean_prompt=clean, use_web=use_web)
+
+    # ------------------------------------------------------------------
+    def generate(self, prompt: str, **kwargs) -> str:
+        """Convenience wrapper that performs routing and generation."""
+        decision = self.route(prompt)
+        return self.manager.generate(decision.clean_prompt, model=decision.model, **kwargs)

--- a/enkibot/modules/rag_service.py
+++ b/enkibot/modules/rag_service.py
@@ -1,0 +1,62 @@
+# enkibot/modules/rag_service.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------------
+# Future Improvements:
+# - Improve modularity to support additional features and services.
+# - Enhance error handling and logging for better maintenance.
+# - Expand unit tests to cover more edge cases.
+# -------------------------------------------------------------------------------
+"""Very small Retrieval‑Augmented Generation helper using FAISS."""
+from __future__ import annotations
+
+from typing import List, Tuple
+import logging
+
+import faiss
+import numpy as np
+from sentence_transformers import SentenceTransformer
+
+logger = logging.getLogger(__name__)
+
+
+class RAGService:
+    """CPU friendly vector search over a set of documents."""
+
+    def __init__(self, embedding_model: str = "intfloat/e5-small-v2"):
+        self.encoder = SentenceTransformer(embedding_model)
+        dim = self.encoder.get_sentence_embedding_dimension()
+        self.index = faiss.IndexFlatL2(dim)
+        self.documents: List[str] = []
+
+    def add_documents(self, docs: List[str]) -> None:
+        """Add raw documents to the index."""
+        embeddings = self.encoder.encode(docs)
+        self.index.add(np.array(embeddings, dtype="float32"))
+        self.documents.extend(docs)
+        logger.info("Indexed %d documents", len(docs))
+
+    def query(self, question: str, top_k: int = 5) -> List[Tuple[str, float]]:
+        """Return the top ``top_k`` documents most relevant to ``question``."""
+        if not self.documents:
+            return []
+        emb = self.encoder.encode([question])
+        scores, ids = self.index.search(np.array(emb, dtype="float32"), top_k)
+        results: List[Tuple[str, float]] = []
+        for idx, score in zip(ids[0], scores[0]):
+            if idx < len(self.documents):
+                results.append((self.documents[idx], float(score)))
+        return results

--- a/enkibot/modules/web_tool.py
+++ b/enkibot/modules/web_tool.py
@@ -1,0 +1,58 @@
+# enkibot/modules/web_tool.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------------
+# Future Improvements:
+# - Improve modularity to support additional features and services.
+# - Enhance error handling and logging for better maintenance.
+# - Expand unit tests to cover more edge cases.
+# -------------------------------------------------------------------------------
+"""Light‑weight web research helper used by local models."""
+from __future__ import annotations
+
+from typing import List, Dict
+import logging
+
+from duckduckgo_search import DDGS
+import requests
+import trafilatura
+
+logger = logging.getLogger(__name__)
+
+
+def web_research(query: str, k: int = 5) -> List[Dict[str, str]]:
+    """Return a list of documents for the given search query.
+
+    Each document is a mapping containing ``title``, ``url`` and ``text`` keys.
+    ``text`` is truncated to a reasonable length for prompt‑embedding.
+    """
+
+    logger.info("Web research for query: %s", query)
+    hits = list(DDGS().text(query, max_results=k))
+    docs: List[Dict[str, str]] = []
+    for hit in hits:
+        try:
+            html = requests.get(hit["href"], timeout=15).text
+            text = trafilatura.extract(html) or ""
+            if text:
+                docs.append({
+                    "title": hit.get("title", ""),
+                    "url": hit["href"],
+                    "text": text[:20000],
+                })
+        except Exception as exc:  # pragma: no cover - network failures common
+            logger.warning("Failed to fetch %s: %s", hit.get("href"), exc)
+    return docs


### PR DESCRIPTION
## Summary
- add LocalModelManager for fast and deep GGUF models
- route prompts between models and add web search + RAG helpers
- document local two-tier model setup and optional dependencies

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897895deb70832a923e3b50c533f5ac