### PR TITLE
Add captcha verification for new chat members

### DIFF
--- a/enkibot/config.py
+++ b/enkibot/config.py
@@ -37,6 +37,8 @@ BOT_NICKNAMES_TO_CHECK = ["enki", "enkibot", "энки", "энкибот", "бо
 
 # Feature toggles
 ENABLE_SPAM_DETECTION = os.getenv('ENKI_BOT_ENABLE_SPAM_DETECTION', 'true').lower() == 'true'
+CAPTCHA_TIMEOUT_SECONDS = int(os.getenv('ENKI_BOT_CAPTCHA_TIMEOUT_SECONDS', '60'))
+CAPTCHA_MAX_ATTEMPTS = int(os.getenv('ENKI_BOT_CAPTCHA_MAX_ATTEMPTS', '3'))
 
 # Community moderation settings
 DEFAULT_SPAM_VOTE_THRESHOLD = int(os.getenv('ENKI_BOT_SPAM_VOTE_THRESHOLD', '3'))


### PR DESCRIPTION
## Summary
- Add configurable captcha timeouts and attempt limits
- Track globally verified users in SQL Server
- Restrict new members and require button or math captcha before unmuting

## Testing
- `python -m py_compile enkibot/config.py enkibot/utils/database.py enkibot/core/telegram_handlers.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897a4f4934c832a80c4c10d70664f16