### PR TITLE
Add video note transcription support

### DIFF
--- a/enkibot/lang/en.json
+++ b/enkibot/lang/en.json
@@ -115,7 +115,11 @@
     "voice_message_received": "Received your voice message. Processing...",
     "voice_transcription_failed": "Sorry, I couldn't understand the audio in that message.",
     "voice_transcription_header": "Transcription:",
-    "voice_translation_header": "Translation (Russian):"
+    "voice_translation_header": "Translation (Russian):",
+    "video_message_received": "Received your video note. Processing...",
+    "video_transcription_failed": "Sorry, I couldn't understand the audio in that video.",
+    "video_transcription_header": "Video transcription:",
+    "video_translation_header": "Video translation (Russian):"
   },
   "weather_conditions_map": {
     "clear_sky": "Clear sky",

--- a/enkibot/lang/ru.json
+++ b/enkibot/lang/ru.json
@@ -116,7 +116,11 @@
     "voice_message_received": "Получил ваше голосовое сообщение. Обрабатываю...",
     "voice_transcription_failed": "Извините, я не смог разобрать аудио в этом сообщении.",
     "voice_transcription_header": "Транскрипция:",
-    "voice_translation_header": "Перевод (на русский):"
+    "voice_translation_header": "Перевод (на русский):",
+    "video_message_received": "Получил ваше видео сообщение. Обрабатываю...",
+    "video_transcription_failed": "Извините, я не смог разобрать аудио в этом видео.",
+    "video_transcription_header": "Транскрипция видео:",
+    "video_translation_header": "Перевод видео (на русский):"
   },
   "weather_conditions_map": {
     "clear_sky": "Ясно",


### PR DESCRIPTION
## Summary
- handle Telegram `video_note` messages by downloading the clip, transcribing with Whisper, and replying with the text (and translation when needed)
- register a handler for video note updates alongside voice messages
- extend English and Russian language packs with video note response strings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897a98d2854832a98de8a57b9410b92