### PR TITLE
Support "Hey, Enki!" trigger for AI chat and images

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ EnkiBot is an intelligent and adaptable Telegram assistant designed for rich, co
 
 ## Key Features
 
-* **Multilingual Support**: 
+* **Multilingual Support**:
     * Automatically detects message language using a combination of the current message and recent chat history for improved accuracy.
     * Responds in the detected language.
     * Can attempt to generate new language packs via LLM translation if an unsupported language is detected with high confidence.
@@ -33,6 +33,8 @@ EnkiBot is an intelligent and adaptable Telegram assistant designed for rich, co
     * Latest news (general or topic-specific) via NewsAPI, with support for language/country biasing.
 * **Modular & Extensible Architecture**:
     * Designed with a clean, modular structure (application core, language service, Telegram handlers, individual functional modules) for better maintainability, testability, and scalability.
+* **Natural Language Trigger**:
+    * Start a message with "Hey, Enki!" to ask questions or say "Hey, Enki! Draw ..." to generate images on demand.
 * **Configurable**: Group access restrictions, API keys, and LLM model IDs are managed via environment variables for security and flexibility.
 * **Robust Error Handling**: Includes database logging for critical errors and user-friendly error messages.
 * **(Planned) Darwinian Self-Improvement**: The project includes a foundational structure and conceptual plan for future integration of self-rewriting code and evolutionary capabilities, inspired by concepts like the Darwin Gödel Machine, aiming for autonomous advancement of the bot's Python modules and LLM prompts.

--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -170,6 +170,15 @@ class TelegramHandlerService:
         if is_group and final_trigger_decision: logger.info(f"_is_triggered: True (Group: {current_chat_id}): @M={is_at_mentioned}, NickM={is_nickname_mentioned}, Reply={is_reply_to_bot}")
         return final_trigger_decision
 
+    def _extract_ai_trigger(self, text: str) -> tuple[str, bool]:
+        """Detects natural language invocations like 'Hey, Enki!' and strips them."""
+        pattern = r'^\s*hey[\s,]+enki[!,:]*\s*'
+        match = re.match(pattern, text, re.IGNORECASE)
+        if match:
+            cleaned = text[match.end():].lstrip()
+            return cleaned, True
+        return text, False
+
     async def _is_user_admin(self, chat_id: int, user_id: int, context: ContextTypes.DEFAULT_TYPE) -> bool:
         try:
             member = await context.bot.get_chat_member(chat_id, user_id)
@@ -576,8 +585,9 @@ class TelegramHandlerService:
         await self.log_message_and_profile_tasks(update, context)
         
         chat_id = update.effective_chat.id
-        user_msg_txt = update.message.text
-        
+        user_msg_txt, triggered_by_prefix = self._extract_ai_trigger(update.message.text)
+        user_msg_txt_lower = user_msg_txt.lower()
+
         current_conv_state = context.user_data.get('conversation_state') if context.user_data else None
         pending_action_details = self.pending_action_data.get(chat_id)
 
@@ -592,10 +602,10 @@ class TelegramHandlerService:
             original_msg_id = pending_action_details.get("original_message_id")
             return await self.news_handler.handle_topic_response(update, context, original_msg_id)
 
-        user_msg_txt_lower = user_msg_txt.lower()
+        draw_request = bool(triggered_by_prefix and re.match(r'^\s*draw\b', user_msg_txt_lower))
         if await self.spam_detector.inspect_message(update, context):
             return ConversationHandler.END
-        if not await self._is_triggered(update, context, user_msg_txt_lower):
+        if not (triggered_by_prefix or await self._is_triggered(update, context, user_msg_txt_lower)):
             return None
 
         master_intent_prompts = self.language_service.get_llm_prompt_set("master_intent_classifier")
@@ -608,6 +618,9 @@ class TelegramHandlerService:
         else: 
             logger.error(f"Master intent classification prompt set missing/malformed for lang '{self.language_service.current_lang}'.")
         
+        if draw_request:
+            master_intent = "IMAGE_GENERATION_QUERY"
+
         logger.info(f"Master Intent for '{user_msg_txt[:50]}...' (lang: {self.language_service.current_lang}) classified as: {master_intent}")
 
         next_state: Optional[int] = None


### PR DESCRIPTION
## Summary
- add regex-based detection of messages starting with "Hey, Enki!" and strip the trigger for processing
- route "Hey, Enki! Draw..." requests directly to image generation
- document natural language trigger in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897b84f7edc832ab47cb415db8476c1