### PR TITLE
Log moderation actions to MS SQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ EnkiBot is an intelligent and adaptable Telegram assistant designed for rich, co
     * Start a message with "Hey, Enki!" to ask questions or say "Hey, Enki! Draw ..." to generate images on demand.
 * **Configurable**: Group access restrictions, API keys, and LLM model IDs are managed via environment variables for security and flexibility.
 * **Robust Error Handling**: Includes database logging for critical errors and user-friendly error messages.
+* **Moderation Logging**: Spam and disallowed content detections are logged to the MS SQL database for auditing and future tuning.
 * **(Planned) Darwinian Self-Improvement**: The project includes a foundational structure and conceptual plan for future integration of self-rewriting code and evolutionary capabilities, inspired by concepts like the Darwin Gödel Machine, aiming for autonomous advancement of the bot's Python modules and LLM prompts.
 * **Two-Tier Local Model Support**:
     * Optional router for fully local inference using `llama.cpp` compatible models.

--- a/enkibot/README.md
+++ b/enkibot/README.md
@@ -35,7 +35,8 @@ EnkiBot is an intelligent and adaptable Telegram assistant designed for rich, co
     * Designed with a clean, modular structure (application core, language service, Telegram handlers, individual functional modules) for better maintainability, testability, and scalability.
 * **Configurable**: Group access restrictions, API keys, and LLM model IDs are managed via environment variables for security and flexibility.
 * **Robust Error Handling**: Includes database logging for critical errors and user-friendly error messages.
-* **(Planned) Darwinian Self-Improvement**: The project includes a foundational structure and conceptual plan for future integration of self-rewriting code and evolutionary capabilities, inspired by concepts like the Darwin Gödel Machine, aiming for autonomous advancement of the bot's Python modules and LLM prompts.
+* **Moderation Logging**: Spam and disallowed content detections are stored in the MS SQL database for auditing and refinement.
+* **(Planned) Darwinian Self-Improvement**: The project includes a foundational structure and conceptual plan for future integration of self-rewriting code and evolutionary capabilities, inspired by concepts like the Darwin GÃ¶del Machine, aiming for autonomous advancement of the bot's Python modules and LLM prompts.
 
 ## Technology Stack
 

--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -73,6 +73,7 @@ class EnkiBotApplication:
         )
         self.spam_detector = SpamDetector(
             self.llm_services,
+            self.db_manager,
             enabled=config.ENABLE_SPAM_DETECTION,
         )
         self.stats_manager = StatsManager(self.db_manager)


### PR DESCRIPTION
## Summary
- persist spam moderation events in a new `ModerationLog` table
- record flagged message categories via `SpamDetector`
- document and wire up database-backed moderation logging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897c0fd2ecc832ab535ed6b0a2257ac