### PR TITLE
Ensure chat stats usernames always include '@'

### DIFF
--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -722,7 +722,7 @@ class TelegramHandlerService:
         if stats['top_users']:
             lines.append("Top users:")
             for u in stats['top_users']:
-                name = f"@{u['username']}" if u.get('username') else str(u['user_id'])
+                name = f"@{u['username']}" if u.get('username') else f"@{u['user_id']}"
                 lines.append(f"- {name}: {u['count']}")
         if stats['top_links']:
             lines.append("Top links:")


### PR DESCRIPTION
## Summary
- Prefix '@' to user IDs when usernames are missing in chat statistics so every entry is consistently formatted.

## Testing
- `python -m py_compile enkibot/core/telegram_handlers.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6897df0d2040832aa8f34ee81510e43e