### PR TITLE
feat: add slash command suggestions

### DIFF
--- a/enkibot/main.py
+++ b/enkibot/main.py
@@ -69,8 +69,10 @@ def main() -> None:
         
         logger.info("Initializing EnkiBotApplication...")
         # --- MODIFIED BOT INSTANTIATION ---
-        enkibot_app_instance = EnkiBotApplication(ptb_app) 
+        enkibot_app_instance = EnkiBotApplication(ptb_app)
         enkibot_app_instance.register_handlers() # Call the method to register handlers
+        # Publish default slash commands so clients show helpful suggestions
+        asyncio.run(enkibot_app_instance.handler_service.push_default_commands())
         # --- END MODIFICATION ---
 
         logger.info("Starting EnkiBot polling...")


### PR DESCRIPTION
## Summary
- register default slash commands with Telegram so clients show command hints
- add feature-aware command refresh with admin /toggle_ai support
- call command registration during startup

## Testing
- `pip install python-telegram-bot==20.*`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897e61d00e4832aaee4fabc1b16d04e