### PR TITLE
Fix post-init callback assignment

### DIFF
--- a/enkibot/main.py
+++ b/enkibot/main.py
@@ -77,7 +77,7 @@ def main() -> None:
         async def post_init(application: Application) -> None:
             await enkibot_app_instance.handler_service.push_default_commands()
 
-        ptb_app.post_init(post_init)
+        ptb_app.post_init = post_init
         # --- END MODIFICATION ---
 
         logger.info("Starting EnkiBot polling...")


### PR DESCRIPTION
## Summary
- Assign the post-init callback to the PTB application instead of invoking it as a function

## Testing
- `python -m py_compile enkibot/main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897ec0452f0832a91133e3b87c81694