### PR TITLE
fix: correctly set post-init callback

### DIFF
--- a/enkibot/main.py
+++ b/enkibot/main.py
@@ -78,9 +78,10 @@ def main() -> None:
             Application.builder()
             .token(config.TELEGRAM_BOT_TOKEN)
             .request(request)
-            .post_init(post_init)
             .build()
         )
+        # Register the post_init callback without calling it (avoids NoneType errors)
+        ptb_app.post_init = post_init
 
         logger.info("Initializing EnkiBotApplication...")
         # --- MODIFIED BOT INSTANTIATION ---


### PR DESCRIPTION
## Summary
- register post-init callback by assignment instead of calling it

## Testing
- `python -m py_compile enkibot/main.py`


------
https://chatgpt.com/codex/tasks/task_e_6897f5e95b5c832a81fa83dbe4f170bd