### PR TITLE
Add moderation and utility commands

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -77,6 +77,7 @@ class EnkiBotApplication:
             enabled=config.ENABLE_SPAM_DETECTION,
         )
         self.stats_manager = StatsManager(self.db_manager)
+        self.karma_manager = KarmaManager(self.db_manager)
 
         # Initialize Telegram handlers, passing all necessary services
         self.handler_service = TelegramHandlerService(
@@ -90,6 +91,7 @@ class EnkiBotApplication:
             language_service=self.language_service,
             spam_detector=self.spam_detector,
             stats_manager=self.stats_manager,
+            karma_manager=self.karma_manager,
             allowed_group_ids=config.ALLOWED_GROUP_IDS, # Pass as set
             bot_nicknames=config.BOT_NICKNAMES_TO_CHECK # Pass as list
         )


### PR DESCRIPTION
## Summary
- integrate KarmaManager and expose a /karma leaderboard command
- allow admins to set chat language and reload local caches
- add moderation helpers: quick ban, ban info, mute info

## Testing
- `python -m py_compile enkibot/app.py enkibot/core/telegram_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_6897fa00bfa8832ab55742452617e419