### PR TITLE
Fix AttributeError for forwarded messages

### DIFF
--- a/enkibot/core/intent_handlers/general_handler.py
+++ b/enkibot/core/intent_handlers/general_handler.py
@@ -66,9 +66,9 @@ class GeneralIntentHandler:
         await context.bot.send_chat_action(chat_id=update.effective_chat.id, action=ChatAction.TYPING)
 
         is_forwarded = bool(
-            update.message.forward_from
-            or update.message.forward_from_chat
-            or update.message.forward_sender_name
+            getattr(update.message, "forward_from", None)
+            or getattr(update.message, "forward_from_chat", None)
+            or getattr(update.message, "forward_sender_name", None)
             or getattr(update.message, "forward_date", None)
             or getattr(update.message, "forward_origin", None)
             or getattr(update.message, "is_automatic_forward", False)

--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -710,9 +710,9 @@ class TelegramHandlerService:
             question_for_analysis = self.language_service.get_response_string("replied_message_default_question")
         
         is_forwarded = bool(
-            original_msg.forward_from
-            or original_msg.forward_from_chat
-            or original_msg.forward_sender_name
+            getattr(original_msg, "forward_from", None)
+            or getattr(original_msg, "forward_from_chat", None)
+            or getattr(original_msg, "forward_sender_name", None)
             or getattr(original_msg, "forward_date", None)
             or getattr(original_msg, "forward_origin", None)
             or getattr(original_msg, "is_automatic_forward", False)


### PR DESCRIPTION
## Summary
- Avoid direct access to `forward_from` and related attributes to prevent crashes when forwarding data is missing.
- Apply safe `getattr` checks in both general intent and telegram handlers.

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68980cb90fdc832a9b73b8e9a1525043