### PR TITLE
fix: avoid forward_from attribute error

### DIFF
--- a/enkibot/core/intent_handlers/general_handler.py
+++ b/enkibot/core/intent_handlers/general_handler.py
@@ -30,6 +30,8 @@ from telegram import Update
 from telegram.ext import ContextTypes
 from telegram.constants import ChatAction
 
+from enkibot.utils.message_utils import is_forwarded_message
+
 if TYPE_CHECKING:
     from enkibot.core.language_service import LanguageService
     from enkibot.modules.response_generator import ResponseGenerator
@@ -65,15 +67,7 @@ class GeneralIntentHandler:
         logger.info(f"GeneralIntentHandler: Handling intent '{master_intent}' for: '{user_msg_txt[:70]}...'")
         await context.bot.send_chat_action(chat_id=update.effective_chat.id, action=ChatAction.TYPING)
 
-        is_forwarded = bool(
-            getattr(update.message, "forward_from", None)
-            or getattr(update.message, "forward_from_chat", None)
-            or getattr(update.message, "forward_sender_name", None)
-            or getattr(update.message, "forward_date", None)
-            or getattr(update.message, "forward_origin", None)
-            or getattr(update.message, "is_automatic_forward", False)
-        )
-        if is_forwarded:
+        if is_forwarded_message(update.message):
             analyzer_prompts = self.language_service.get_llm_prompt_set("forwarded_news_fact_checker")
             if analyzer_prompts and "system" in analyzer_prompts:
                 forwarded_text = update.message.text or update.message.caption or ""

--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -73,6 +73,7 @@ from .intent_handlers.news_handler import NewsIntentHandler
 from .intent_handlers.general_handler import GeneralIntentHandler
 from .intent_handlers.image_generation_handler import ImageGenerationIntentHandler
 from enkibot.modules.spam_detector import SpamDetector
+from enkibot.utils.message_utils import is_forwarded_message
 
 logger = logging.getLogger(__name__)
 
@@ -709,15 +710,7 @@ class TelegramHandlerService:
         if len(cleaned_question) < 5: 
             question_for_analysis = self.language_service.get_response_string("replied_message_default_question")
         
-        is_forwarded = bool(
-            getattr(original_msg, "forward_from", None)
-            or getattr(original_msg, "forward_from_chat", None)
-            or getattr(original_msg, "forward_sender_name", None)
-            or getattr(original_msg, "forward_date", None)
-            or getattr(original_msg, "forward_origin", None)
-            or getattr(original_msg, "is_automatic_forward", False)
-        )
-        if is_forwarded:
+        if is_forwarded_message(original_msg):
             analyzer_prompts = self.language_service.get_llm_prompt_set("forwarded_news_fact_checker")
             if not (analyzer_prompts and "system" in analyzer_prompts):
                 logger.error("Prompt set for forwarded news fact-check is missing or malformed.")

--- a/enkibot/utils/message_utils.py
+++ b/enkibot/utils/message_utils.py
@@ -1,0 +1,59 @@
+# enkibot/utils/message_utils.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+#
+# -------------------------------------------------------------------------------
+# Future Improvements:
+# - Improve modularity to support additional features and services.
+# - Enhance error handling and logging for better maintenance.
+# - Expand unit tests to cover more edge cases.
+# -------------------------------------------------------------------------------
+
+"""Helper utilities for working with Telegram messages."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def is_forwarded_message(message: Any) -> bool:
+    """Return ``True`` if the provided Telegram *message* appears to be forwarded.
+
+    This checks several possible attributes that may indicate a forwarded
+    message across different versions of the Telegram Bot API. Any missing
+    attributes are safely ignored to avoid raising :class:`AttributeError`.
+    """
+    if message is None:
+        return False
+
+    attrs_to_check = (
+        "forward_origin",
+        "forward_from",
+        "forward_from_chat",
+        "forward_sender_name",
+        "forward_date",
+    )
+    for attr in attrs_to_check:
+        try:
+            if getattr(message, attr):
+                return True
+        except AttributeError:
+            continue
+
+    try:
+        return bool(getattr(message, "is_automatic_forward"))
+    except AttributeError:
+        return False


### PR DESCRIPTION
## Summary
- add `is_forwarded_message` utility to safely detect forwarded messages
- use helper in general intent and telegram handlers to avoid AttributeError with new Telegram API

## Testing
- `python -m py_compile enkibot/utils/message_utils.py enkibot/core/intent_handlers/general_handler.py enkibot/core/telegram_handlers.py`


------
https://chatgpt.com/codex/tasks/task_e_68980eea2cbc832ab6731055a5e879fb