### PR TITLE
feat: add zero-trust spam guard

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -95,7 +95,13 @@ class EnkiBotApplication:
             allowed_group_ids=config.ALLOWED_GROUP_IDS, # Pass as set
             bot_nicknames=config.BOT_NICKNAMES_TO_CHECK # Pass as list
         )
-        
+
+        # Allow the spam detector to trigger captcha challenges via the
+        # Telegram handler service.
+        self.spam_detector.set_captcha_callback(
+            self.handler_service.start_captcha
+        )
+
         logger.info("EnkiBotApplication initialized all services.")
 
     def register_handlers(self):

--- a/enkibot/config.py
+++ b/enkibot/config.py
@@ -40,6 +40,40 @@ ENABLE_SPAM_DETECTION = os.getenv('ENKI_BOT_ENABLE_SPAM_DETECTION', 'true').lowe
 CAPTCHA_TIMEOUT_SECONDS = int(os.getenv('ENKI_BOT_CAPTCHA_TIMEOUT_SECONDS', '60'))
 CAPTCHA_MAX_ATTEMPTS = int(os.getenv('ENKI_BOT_CAPTCHA_MAX_ATTEMPTS', '3'))
 
+# Zero-Trust moderation configuration. These values control how the spam
+# detector treats new or unverified users and how it scores their first
+# messages. All values can be overridden with environment variables.
+ZERO_TRUST_SETTINGS = {
+    "watch_new_user_window_sec": int(os.getenv('ENKI_BOT_ZT_NEW_USER_WINDOW', '3600')),
+    "watch_first_messages": int(os.getenv('ENKI_BOT_ZT_FIRST_MESSAGES', '5')),
+    "global_thresholds": {
+        "delete": float(os.getenv('ENKI_BOT_ZT_DELETE_THRESHOLD', '0.75')),
+        "ban": float(os.getenv('ENKI_BOT_ZT_BAN_THRESHOLD', '0.95')),
+        "mute_then_captcha": float(os.getenv('ENKI_BOT_ZT_MUTE_THRESHOLD', '0.80')),
+    },
+    "heuristics": {
+        "url_in_first_msg": float(os.getenv('ENKI_BOT_ZT_URL_RISK', '0.10')),
+        "many_mentions": float(os.getenv('ENKI_BOT_ZT_MANY_MENTIONS_RISK', '0.10')),
+        "all_caps_long": float(os.getenv('ENKI_BOT_ZT_ALL_CAPS_RISK', '0.10')),
+        "repeated_chars": float(os.getenv('ENKI_BOT_ZT_REPEAT_RISK', '0.05')),
+        "keyword_hits": float(os.getenv('ENKI_BOT_ZT_KEYWORD_RISK', '0.15')),
+    },
+    "lists": {
+        "domain_blocklist": set(filter(None, os.getenv(
+            'ENKI_BOT_ZT_DOMAIN_BLOCKLIST', 't.me/joinchat,bit.ly,cutt.ly'
+        ).split(','))),
+        "keyword_blocklist": set(filter(None, os.getenv(
+            'ENKI_BOT_ZT_KEYWORD_BLOCKLIST',
+            'free crypto,giveaway,xxx,adult cam,telegram view,loan approval,work from home $,forex vip'
+        ).split(','))),
+    },
+    "logging": {
+        "admin_chat_id": int(os.getenv('ENKI_BOT_ZT_ADMIN_CHAT_ID'))
+        if os.getenv('ENKI_BOT_ZT_ADMIN_CHAT_ID')
+        else None,
+    },
+}
+
 # Community moderation settings
 DEFAULT_SPAM_VOTE_THRESHOLD = int(os.getenv('ENKI_BOT_SPAM_VOTE_THRESHOLD', '3'))
 SPAM_VOTE_TIME_WINDOW_MINUTES = int(os.getenv('ENKI_BOT_SPAM_VOTE_WINDOW_MINUTES', '60'))

--- a/enkibot/core/llm_services.py
+++ b/enkibot/core/llm_services.py
@@ -275,10 +275,12 @@ class LLMServices:
                 result = response.results[0]
                 # Extract minimal useful information. ``result`` is an
                 # OpenAI object; convert to a standard dict for downstream
-                # processing.
+                # processing. Include ``category_scores`` so callers can
+                # compute risk levels without re-parsing the OpenAI object.
                 return {
                     "flagged": bool(getattr(result, "flagged", False)),
                     "categories": getattr(result, "categories", {}),
+                    "category_scores": getattr(result, "category_scores", {}),
                 }
         except openai.APIError as e:
             logger.error(f"OpenAI Moderation API Error: {e.message}")

--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -262,6 +262,15 @@ class TelegramHandlerService:
         task = asyncio.create_task(self._captcha_timeout(user.id))
         self.pending_captchas[user.id]["task"] = task
 
+    async def start_captcha(self, user, chat_id: int, context: ContextTypes.DEFAULT_TYPE):
+        """Public wrapper to initiate captcha verification for a user.
+
+        This exposes the existing captcha mechanism to other modules
+        (e.g., the spam detector) without requiring them to know about the
+        private ``_start_captcha`` implementation details.
+        """
+        await self._start_captcha(user, chat_id, context)
+
     async def _captcha_timeout(self, user_id: int):
         await asyncio.sleep(bot_config.CAPTCHA_TIMEOUT_SECONDS)
         info = self.pending_captchas.get(user_id)


### PR DESCRIPTION
## Summary
- extend OpenAI moderation wrapper to expose category scores
- add configurable zero-trust settings for heuristics and risk thresholds
- implement zero-trust spam detector with risk scoring and captcha integration
- expose captcha starter for other modules

## Testing
- `python -m py_compile enkibot/core/llm_services.py enkibot/config.py enkibot/core/telegram_handlers.py enkibot/app.py enkibot/modules/spam_detector.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_689825171308832a89e6ab73bec40dca