### PR TITLE
Add community moderation service

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -37,6 +37,7 @@ from enkibot.core.telegram_handlers import TelegramHandlerService
 from enkibot.modules.karma_manager import KarmaManager
 from enkibot.modules.spam_detector import SpamDetector
 from enkibot.modules.stats_manager import StatsManager
+from enkibot.modules.community_moderation import CommunityModerationService
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +79,9 @@ class EnkiBotApplication:
         )
         self.stats_manager = StatsManager(self.db_manager)
         self.karma_manager = KarmaManager(self.db_manager)
+        self.community_moderation = CommunityModerationService(
+            admin_chat_id=config.REPORTS_CHANNEL_ID
+        )
 
         # Initialize Telegram handlers, passing all necessary services
         self.handler_service = TelegramHandlerService(
@@ -92,6 +96,7 @@ class EnkiBotApplication:
             spam_detector=self.spam_detector,
             stats_manager=self.stats_manager,
             karma_manager=self.karma_manager,
+            community_moderation=self.community_moderation,
             allowed_group_ids=config.ALLOWED_GROUP_IDS, # Pass as set
             bot_nicknames=config.BOT_NICKNAMES_TO_CHECK # Pass as list
         )

--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -62,6 +62,7 @@ if TYPE_CHECKING:
     from enkibot.modules.spam_detector import SpamDetector
     from enkibot.modules.stats_manager import StatsManager
     from enkibot.modules.karma_manager import KarmaManager
+    from enkibot.modules.community_moderation import CommunityModerationService
     from .intent_handlers.weather_handler import WeatherIntentHandler
     from .intent_handlers.news_handler import NewsIntentHandler
     from .intent_handlers.general_handler import GeneralIntentHandler
@@ -94,6 +95,7 @@ class TelegramHandlerService:
                  spam_detector: 'SpamDetector',
                  stats_manager: 'StatsManager',
                  karma_manager: 'KarmaManager',
+                 community_moderation: 'CommunityModerationService',
                  allowed_group_ids: set,
                  bot_nicknames: list
                 ):
@@ -109,6 +111,7 @@ class TelegramHandlerService:
         self.spam_detector = spam_detector
         self.stats_manager = stats_manager
         self.karma_manager = karma_manager
+        self.community_moderation = community_moderation
         
         self.allowed_group_ids = allowed_group_ids 
         self.bot_nicknames = bot_nicknames
@@ -960,74 +963,10 @@ class TelegramHandlerService:
         return await self.news_handler.handle_command_entry(update, context)
 
     async def report_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        if not update.message or not update.message.reply_to_message:
-            await update.message.reply_text("Reply to a message with /report to alert admins.")
-            return
-        reported = update.message.reply_to_message
-        chat_id = update.effective_chat.id
-        report_text = f"\U0001F6A8 Reported message by @{reported.from_user.username or reported.from_user.id}:"  # 🚨
-        if reported.text:
-            report_text += f"\n{reported.text}"
-        try:
-            if bot_config.REPORTS_CHANNEL_ID:
-                await context.bot.forward_message(bot_config.REPORTS_CHANNEL_ID, chat_id, reported.message_id)
-                await context.bot.send_message(bot_config.REPORTS_CHANNEL_ID, report_text)
-            else:
-                admins = await context.bot.get_chat_administrators(chat_id)
-                for admin in admins:
-                    if not admin.user.is_bot:
-                        try:
-                            await context.bot.send_message(admin.user.id, report_text)
-                        except Exception as e:
-                            logger.error(f"Failed to notify admin {admin.user.id}: {e}")
-            await update.message.reply_text("Thanks, the admins have been notified.")
-        except Exception as e:
-            logger.error(f"Error handling report command: {e}", exc_info=True)
+        await self.community_moderation.cmd_report(update, context)
 
     async def spam_vote_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-        if not update.message or not update.message.reply_to_message:
-            await update.message.reply_text("Reply to a message with /spam to vote for banning the sender.")
-            return
-        chat_id = update.effective_chat.id
-        reporter_id = update.effective_user.id if update.effective_user else None
-        if reporter_id is None:
-            return
-        try:
-            member = await context.bot.get_chat_member(chat_id, reporter_id)
-            if member.status in ("administrator", "creator"):
-                await update.message.reply_text("Admins can ban users directly without voting.")
-                return
-        except Exception:
-            pass
-        target_user = update.message.reply_to_message.from_user
-        try:
-            target_member = await context.bot.get_chat_member(chat_id, target_user.id)
-            if target_member.status in ("administrator", "creator"):
-                await update.message.reply_text("Cannot vote to ban an admin.")
-                return
-        except Exception:
-            pass
-        added = await self.db_manager.add_spam_vote(chat_id, target_user.id, reporter_id)
-        if not added:
-            await update.message.reply_text("You have already voted to ban this user.")
-            return
-        threshold = await self.db_manager.get_spam_vote_threshold(chat_id, bot_config.DEFAULT_SPAM_VOTE_THRESHOLD)
-        count = await self.db_manager.count_spam_votes(chat_id, target_user.id, bot_config.SPAM_VOTE_TIME_WINDOW_MINUTES)
-        if count >= threshold:
-            try:
-                await context.bot.ban_chat_member(chat_id, target_user.id)
-                await update.message.reply_html(
-                    f"User {target_user.mention_html()} was banned by community vote for spam."
-                )
-                try:
-                    await context.bot.delete_message(chat_id, update.message.reply_to_message.message_id)
-                except Exception:
-                    pass
-            except Exception as e:
-                logger.error(f"Failed to ban user {target_user.id}: {e}")
-            await self.db_manager.clear_spam_votes(chat_id, target_user.id)
-        else:
-            await update.message.reply_text(f"Spam vote recorded ({count}/{threshold}).")
+        await self.community_moderation.cmd_vote(update, context, reason="spam")
 
     async def ban_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if not update.message or not update.message.reply_to_message:
@@ -1413,6 +1352,7 @@ class TelegramHandlerService:
         self.application.add_handler(MessageHandler(filters.StatusUpdate.LEFT_CHAT_MEMBER, self.handle_left_chat_member))
         self.application.add_handler(CallbackQueryHandler(self.captcha_button_callback, pattern=r"^captcha_button:"))
         self.application.add_handler(CallbackQueryHandler(self.captcha_math_callback, pattern=r"^captcha_math:"))
+        self.application.add_handler(CallbackQueryHandler(self.community_moderation.on_report_reason, pattern=r"^REPORT:"))
         
         conv_handler = ConversationHandler(
             entry_points=[

--- a/enkibot/modules/community_moderation.py
+++ b/enkibot/modules/community_moderation.py
@@ -1,0 +1,296 @@
+# enkibot/modules/community_moderation.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Community moderation helpers.
+
+This module implements a lightweight, in-memory community moderation
+system inspired by more advanced crowd‑moderation examples.  It supports
+reporting with a reason picker, weighted voting with basic trust scores
+and automatic actions once dynamic thresholds are met.  The state is not
+persisted between restarts but provides a foundation that can later be
+extended to a database-backed implementation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Dict, Tuple, Optional
+
+from telegram import (
+    Update,
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+)
+from telegram.ext import ContextTypes
+
+
+# ---------------------------------------------------------------------------
+# Constants and simple helpers
+# ---------------------------------------------------------------------------
+
+CONSENSUS_WINDOW_MIN = 15
+TRUST_MIN, TRUST_MAX = 0.2, 1.5
+VOTE_LIMIT_PER_DAY = 10
+MIN_CHAT_TENURE_HOURS = 24
+
+THRESH_HIDE = 2.0
+THRESH_TEMPBAN = 5.0
+THRESH_PERMABAN = 7.0
+
+TEMPBAN_HOURS = 24
+
+REASON_CHOICES = [
+    ("spam", "Spam/Ads"),
+    ("scam", "Scam/Phishing"),
+    ("nsfw", "NSFW"),
+    ("hate", "Hate/Harassment"),
+    ("offtopic", "Off-topic"),
+    ("other", "Other"),
+]
+
+
+def now() -> datetime:
+    return datetime.utcnow()
+
+
+@dataclass
+class Case:
+    case_id: int
+    chat_id: int
+    target_user_id: int
+    first_msg_id: int
+    opened_ts: datetime
+    reason: str
+    votes: Dict[int, float] = field(default_factory=dict)
+    status: str = "open"
+
+
+class CommunityModerationService:
+    """Minimal community moderation manager."""
+
+    def __init__(self, admin_chat_id: Optional[int] = None) -> None:
+        self.admin_chat_id = admin_chat_id
+        self.cases: Dict[int, Case] = {}
+        self.case_index: Dict[Tuple[int, int, int], int] = {}
+        self.next_case_id = 1
+        self.trust: Dict[Tuple[int, int], float] = {}
+        self.mem_state: Dict[Tuple[int, int], Dict[str, any]] = {}
+
+    # ------------------------------------------------------------------
+    # Case and trust helpers
+    # ------------------------------------------------------------------
+    def _get_or_open_case(self, chat_id: int, target_user_id: int, msg_id: int, reason: str) -> Case:
+        key = (chat_id, target_user_id, msg_id)
+        cid = self.case_index.get(key)
+        if cid:
+            return self.cases[cid]
+        case = Case(self.next_case_id, chat_id, target_user_id, msg_id, now(), reason)
+        self.cases[self.next_case_id] = case
+        self.case_index[key] = self.next_case_id
+        self.next_case_id += 1
+        return case
+
+    def _already_voted(self, case: Case, voter_id: int) -> bool:
+        return voter_id in case.votes
+
+    def _add_vote(self, case: Case, voter_id: int, base: float = 1.0) -> float:
+        trust = self.trust.get((case.chat_id, voter_id), 1.0)
+        trust = max(TRUST_MIN, min(TRUST_MAX, trust))
+        weight = base * trust
+        case.votes[voter_id] = weight
+        return weight
+
+    def _effective_score(self, case: Case) -> float:
+        window_start = now() - timedelta(minutes=CONSENSUS_WINDOW_MIN)
+        return sum(weight for weight in case.votes.values() if window_start <= case.opened_ts)
+
+    # ------------------------------------------------------------------
+    # Eligibility tracking
+    # ------------------------------------------------------------------
+    def _eligible_to_vote(self, update: Update) -> Tuple[bool, str]:
+        chat = update.effective_chat
+        user = update.effective_user
+        key = (chat.id, user.id)
+        st = self.mem_state.get(key, {})
+
+        joined_ts = st.get("joined_ts")
+        if not joined_ts:
+            joined_ts = now()
+            st["joined_ts"] = joined_ts
+        if now() - joined_ts < timedelta(hours=MIN_CHAT_TENURE_HOURS):
+            self.mem_state[key] = st
+            return False, "You need more time in this chat before voting."
+
+        votes = [t for t in st.get("votes", []) if now() - t < timedelta(days=1)]
+        if len(votes) >= VOTE_LIMIT_PER_DAY:
+            st["votes"] = votes
+            self.mem_state[key] = st
+            return False, "Daily vote limit reached."
+        st["votes"] = votes
+        self.mem_state[key] = st
+        return True, ""
+
+    def _record_vote_usage(self, update: Update) -> None:
+        chat = update.effective_chat
+        user = update.effective_user
+        key = (chat.id, user.id)
+        st = self.mem_state.get(key, {})
+        votes = st.get("votes", [])
+        votes.append(now())
+        st["votes"] = votes
+        self.mem_state[key] = st
+
+    # ------------------------------------------------------------------
+    # Actions
+    # ------------------------------------------------------------------
+    async def _hide_message(self, context: ContextTypes.DEFAULT_TYPE, chat_id: int, msg_id: int) -> None:
+        try:
+            await context.bot.delete_message(chat_id, msg_id)
+        except Exception:
+            pass
+
+    async def _temp_ban(self, context: ContextTypes.DEFAULT_TYPE, chat_id: int, user_id: int, hours: int = TEMPBAN_HOURS) -> None:
+        try:
+            until = int((now() + timedelta(hours=hours)).timestamp())
+            await context.bot.ban_chat_member(chat_id, user_id, until_date=until)
+        except Exception:
+            pass
+
+    async def _permaban(self, context: ContextTypes.DEFAULT_TYPE, chat_id: int, user_id: int) -> None:
+        try:
+            await context.bot.ban_chat_member(chat_id, user_id)
+        except Exception:
+            pass
+
+    async def _apply_decision(self, context: ContextTypes.DEFAULT_TYPE, case: Case, score: float, msg_id: Optional[int]) -> Optional[str]:
+        action = None
+        if score >= THRESH_PERMABAN:
+            action = "permaban"
+        elif score >= THRESH_TEMPBAN:
+            action = "tempban"
+        elif score >= THRESH_HIDE:
+            action = "hide"
+
+        if not action:
+            return None
+
+        if action == "hide" and msg_id:
+            await self._hide_message(context, case.chat_id, msg_id)
+        elif action == "tempban":
+            await self._temp_ban(context, case.chat_id, case.target_user_id)
+        elif action == "permaban":
+            await self._permaban(context, case.chat_id, case.target_user_id)
+
+        if self.admin_chat_id:
+            try:
+                await context.bot.send_message(
+                    self.admin_chat_id,
+                    f"Case #{case.case_id} action: {action} (score {score:.2f})",
+                )
+            except Exception:
+                pass
+        return action
+
+    # ------------------------------------------------------------------
+    # Public command handlers
+    # ------------------------------------------------------------------
+    async def cmd_report(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        if not update.message or not update.message.reply_to_message:
+            await update.effective_message.reply_text("Reply to a message with /report to report it.")
+            return
+        buttons = [
+            [InlineKeyboardButton(lbl, callback_data=f"REPORT:{code}:{update.message.reply_to_message.message_id}")]
+            for code, lbl in REASON_CHOICES
+        ]
+        kb = InlineKeyboardMarkup(buttons)
+        await update.effective_message.reply_text("Choose a reason to report:", reply_markup=kb)
+
+    async def on_report_reason(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+        q = update.callback_query
+        await q.answer()
+        try:
+            _, reason, msg_id_str = q.data.split(":", 2)
+            msg_id = int(msg_id_str)
+        except Exception:
+            return
+
+        ok, why = self._eligible_to_vote(update)
+        if not ok:
+            await q.edit_message_text(why)
+            return
+
+        chat = update.effective_chat
+        user = update.effective_user
+        try:
+            orig = await context.bot.forward_message(chat.id, chat.id, msg_id)
+            target_id = orig.forward_from.id if orig.forward_from else None
+        except Exception:
+            target_id = None
+        if not target_id:
+            await q.edit_message_text("Could not identify target user.")
+            return
+
+        case = self._get_or_open_case(chat.id, target_id, msg_id, reason)
+        if self._already_voted(case, user.id):
+            await q.edit_message_text("You already reported this case.")
+            return
+        self._add_vote(case, user.id, base=1.0)
+        self._record_vote_usage(update)
+        score = self._effective_score(case)
+        await q.edit_message_text("Thanks, the moderators have been notified.")
+        await self._apply_decision(context, case, score, msg_id)
+        if self.admin_chat_id:
+            try:
+                await context.bot.send_message(
+                    self.admin_chat_id,
+                    f"Report: case {case.case_id} voter {user.id} reason {reason} score {score:.2f}",
+                )
+            except Exception:
+                pass
+
+    async def cmd_vote(self, update: Update, context: ContextTypes.DEFAULT_TYPE, reason: str = "spam") -> None:
+        if not update.message or not update.message.reply_to_message:
+            await update.effective_message.reply_text("Reply to the offending message with /spam.")
+            return
+        voter = update.effective_user
+        target = update.message.reply_to_message.from_user
+        if voter.id == target.id:
+            await update.effective_message.reply_text("You cannot vote on yourself.")
+            return
+
+        ok, why = self._eligible_to_vote(update)
+        if not ok:
+            await update.effective_message.reply_text(why)
+            return
+
+        case = self._get_or_open_case(update.effective_chat.id, target.id, update.message.reply_to_message.message_id, reason)
+        if self._already_voted(case, voter.id):
+            await update.effective_message.reply_text("You already voted on this case.")
+            return
+        w = self._add_vote(case, voter.id, base=1.0)
+        self._record_vote_usage(update)
+        score = self._effective_score(case)
+        await update.effective_message.reply_text("Vote recorded. Mods notified.")
+        await self._apply_decision(context, case, score, update.message.reply_to_message.message_id)
+        if self.admin_chat_id:
+            try:
+                await context.bot.send_message(
+                    self.admin_chat_id,
+                    f"Vote: case {case.case_id} voter {voter.id} +{w:.2f} score {score:.2f}",
+                )
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- add in-memory community moderation service with reason-picker reporting and weighted votes
- integrate community moderation into app initialization and telegram handlers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689827507710832a80a36519aa88237f