### PR TITLE
Add text splitter utility and integrate into handlers

### DIFF
--- a/enkibot/core/intent_handlers/news_handler.py
+++ b/enkibot/core/intent_handlers/news_handler.py
@@ -28,6 +28,7 @@ from telegram import Update
 from telegram.ext import ContextTypes, ConversationHandler
 from telegram.constants import ChatAction
 from enkibot.utils.quota_middleware import enforce_user_quota
+from enkibot.utils.text_splitter import split_text_into_chunks
 
 if TYPE_CHECKING:
     from enkibot.core.language_service import LanguageService
@@ -95,7 +96,12 @@ class NewsIntentHandler:
                         system_prompt=compiler_prompts["system"],
                         user_prompt_template=compiler_prompts["user_template"]
                     )
-                    await update.message.reply_text(compiled_response, disable_web_page_preview=True, reply_to_message_id=reply_to_id)
+                    for idx, chunk in enumerate(split_text_into_chunks(compiled_response)):
+                        await update.message.reply_text(
+                            chunk,
+                            disable_web_page_preview=True,
+                            reply_to_message_id=reply_to_id if idx == 0 else None,
+                        )
         
         except Exception as e:
             logger.error(f"NewsHandler: Unhandled exception in _process_news_request for topic '{topic}': {e}", exc_info=True)

--- a/enkibot/core/intent_handlers/weather_handler.py
+++ b/enkibot/core/intent_handlers/weather_handler.py
@@ -28,6 +28,7 @@ from telegram import Update
 from telegram.ext import ContextTypes, ConversationHandler
 from telegram.constants import ChatAction
 from enkibot.utils.quota_middleware import enforce_user_quota
+from enkibot.utils.text_splitter import split_text_into_chunks
 
 if TYPE_CHECKING:
     from enkibot.core.language_service import LanguageService
@@ -77,7 +78,8 @@ class WeatherIntentHandler:
                     system_prompt=compiler_prompts["system"],
                     user_prompt_template=compiler_prompts["user_template"]
                 )
-                await update.message.reply_text(compiled_response, reply_to_message_id=reply_to_id)
+                for idx, chunk in enumerate(split_text_into_chunks(compiled_response)):
+                    await update.message.reply_text(chunk, reply_to_message_id=reply_to_id if idx == 0 else None)
         else:
             await update.message.reply_text(self.language_service.get_response_string("weather_city_not_found", location=city), reply_to_message_id=reply_to_id)
         return ConversationHandler.END

--- a/enkibot/utils/text_splitter.py
+++ b/enkibot/utils/text_splitter.py
@@ -1,0 +1,61 @@
+# enkibot/utils/text_splitter.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+# -------------------------------------------------------------------------------
+# Future Improvements:
+# - Improve modularity to support additional features and services.
+# - Enhance error handling and logging for better maintenance.
+# - Expand unit tests to cover more edge cases.
+# -------------------------------------------------------------------------------
+"""Utility helpers for splitting long text into smaller chunks."""
+
+from __future__ import annotations
+
+from typing import List
+import re
+
+MAX_TELEGRAM_MESSAGE_LENGTH = 4096
+
+
+def split_text_into_chunks(text: str, max_chunk_size: int = MAX_TELEGRAM_MESSAGE_LENGTH) -> List[str]:
+    """Split *text* into chunks not exceeding *max_chunk_size* characters.
+
+    The function attempts to respect whitespace boundaries so that words or
+    existing newlines are not arbitrarily broken whenever possible.
+    """
+    if not text:
+        return []
+
+    tokens = re.split(r"(\s+)", text)
+    chunks: List[str] = []
+    current = ""
+
+    for token in tokens:
+        if len(current) + len(token) <= max_chunk_size:
+            current += token
+        else:
+            if current:
+                chunks.append(current.rstrip())
+            current = token.lstrip()
+            # If a single token itself exceeds max_chunk_size, hard split it
+            while len(current) > max_chunk_size:
+                chunks.append(current[:max_chunk_size])
+                current = current[max_chunk_size:]
+
+    if current:
+        chunks.append(current.rstrip())
+
+    return [c for c in chunks if c]


### PR DESCRIPTION
## Summary
- add utility to split long texts into Telegram-safe chunks
- use splitter when sending general, weather, and news responses

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68983a397470832aa9489664c1123acd