### PR TITLE
Fix Forwarded filter and index initialization

### DIFF
--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -266,7 +266,7 @@ class FactCheckBot:
     def register(self) -> None:
         self.app.add_handler(CommandHandler("factcheck", self.cmd_factcheck))
         self.app.add_handler(
-            MessageHandler(filters.Forwarded() & (filters.TEXT | filters.CAPTION), self.on_forward)
+            MessageHandler(filters.FORWARDED & (filters.TEXT | filters.CAPTION), self.on_forward)
         )
         self.app.add_handler(CallbackQueryHandler(self.on_factconfig_cb, pattern=r"^FC:"))
         self.app.add_handler(CommandHandler("factconfig", self.cmd_factconfig))

--- a/enkibot/utils/database.py
+++ b/enkibot/utils/database.py
@@ -33,6 +33,7 @@
 # === EnkiBot Database Utilities ===
 # ==================================================================================================
 import logging
+import re
 import pyodbc
 from typing import List, Dict, Any, Optional
 from datetime import date
@@ -629,10 +630,10 @@ def initialize_database(): # This function defines and uses DatabaseManager loca
                 obj_name_to_check = name  # For tables, this is the table name. For indexes, this is the index name.
                 table_for_index = ""
                 if is_idx:
-                    # Attempt to parse table name from index name, e.g., IX_TableName_Column -> TableName
-                    parts = name.split('_')
-                    if len(parts) > 1:
-                        table_for_index = parts[1]  # This is a heuristic
+                    # Extract table name from the CREATE INDEX statement
+                    match = re.search(r"ON\s+([\w\.]+)", query, re.IGNORECASE)
+                    if match:
+                        table_for_index = match.group(1)
                     else:
                         logger.warning(f"Could not determine table for index {name}")
                         continue


### PR DESCRIPTION
## Summary
- Use correct FORWARDED filter constant in FactCheck module
- Derive table name from SQL when creating indexes to avoid duplicates

## Testing
- `python -m py_compile enkibot/modules/fact_check.py enkibot/utils/database.py`


------
https://chatgpt.com/codex/tasks/task_e_689841e0c1e8832a8584f9b91ddf703e