### PR TITLE
Fix index existence check during DB initialization

### DIFF
--- a/enkibot/utils/database.py
+++ b/enkibot/utils/database.py
@@ -639,7 +639,8 @@ def initialize_database(): # This function defines and uses DatabaseManager loca
                         continue
 
                 check_q = (
-                    "SELECT name FROM sys.indexes WHERE name = ? AND object_id = OBJECT_ID(?)"
+                    "SELECT i.name FROM sys.indexes i JOIN sys.tables t ON i.object_id = t.object_id "
+                    "WHERE i.name = ? AND t.name = ?"
                     if is_idx
                     else "SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_NAME = ?"
                 )


### PR DESCRIPTION
## Summary
- Ensure existing indexes are detected by joining sys.indexes with sys.tables before creation

## Testing
- `python -m py_compile enkibot/utils/database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689843187cb8832aa4c3fa55547ea4ad