### PR TITLE
Fix index initialization check in database setup

### DIFF
--- a/enkibot/utils/database.py
+++ b/enkibot/utils/database.py
@@ -630,8 +630,10 @@ def initialize_database(): # This function defines and uses DatabaseManager loca
                 obj_name_to_check = name  # For tables, this is the table name. For indexes, this is the index name.
                 table_for_index = ""
                 if is_idx:
-                    # Extract table name from the CREATE INDEX statement
-                    match = re.search(r"ON\s+([\w\.]+)", query, re.IGNORECASE)
+                    # Extract table name from the CREATE INDEX statement.
+                    # Use a word boundary before 'ON' so we don't match strings like
+                    # 'NameVariation ON'.
+                    match = re.search(r"\bON\s+([\w\.]+)", query, re.IGNORECASE)
                     if match:
                         table_for_index = match.group(1)
                     else:


### PR DESCRIPTION
## Summary
- avoid recreating existing indexes by correctly parsing table name in index creation SQL during DB initialization

## Testing
- `pytest`
- `python -m py_compile enkibot/utils/database.py`


------
https://chatgpt.com/codex/tasks/task_e_689847e772b4832a9c5c08edf458f7f6