### PR TITLE
Handle captioned forwarded messages

### DIFF
--- a/enkibot/utils/message_utils.py
+++ b/enkibot/utils/message_utils.py
@@ -57,3 +57,20 @@ def is_forwarded_message(message: Any) -> bool:
         return bool(getattr(message, "is_automatic_forward"))
     except AttributeError:
         return False
+
+
+def get_text(message: Any) -> str | None:
+    """Return text or caption from a Telegram *message*.
+
+    Many messages such as photos or videos carry their textual content in the
+    ``caption`` field rather than ``text``.  This helper consolidates both
+    attributes so handlers can process any user supplied text without worrying
+    about the underlying message type.
+    """
+
+    if message is None:
+        return None
+
+    text = getattr(message, "text", None)
+    caption = getattr(message, "caption", None)
+    return text or caption


### PR DESCRIPTION
## Summary
- Ensure forwarded fact-checks read text from message captions
- Add helper to extract text or caption from Telegram messages
- Register handlers for forwarded media to avoid skipping captioned posts

## Testing
- `python -m py_compile enkibot/modules/fact_check.py enkibot/utils/message_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_689849ca34fc832ab8ec3e14d33646e1