### PR TITLE
Add web fact checking reactions for forwarded news

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -41,7 +41,7 @@ from enkibot.modules.community_moderation import CommunityModerationService
 from enkibot.modules.fact_check import (
     FactChecker,
     FactCheckBot,
-    Fetcher,
+    DuckDuckGoFetcher,
     SatireDetector,
     StanceModel,
 )
@@ -117,16 +117,10 @@ class EnkiBotApplication:
         # ------------------------------------------------------------------
         # Fact checking subsystem (skeleton implementation)
         # ------------------------------------------------------------------
-        class _DummyFetcher(Fetcher):
-            pass
-
-        class _DummyStance(StanceModel):
-            pass
-
-        self.fact_checker = FactChecker(fetcher=_DummyFetcher(), stance=_DummyStance())
+        self.fact_checker = FactChecker(fetcher=DuckDuckGoFetcher(), stance=StanceModel())
 
         def _default_fact_cfg(_chat_id: int) -> dict:
-            return {"satire": {"enabled": False}, "auto": {"auto_check_news": False}}
+            return {"satire": {"enabled": False}, "auto": {"auto_check_news": True}}
 
         self.fact_check_bot = FactCheckBot(
             app=self.ptb_application,


### PR DESCRIPTION
## Summary
- Fix caption filter causing bool iterable error
- Add DuckDuckGo-backed fact checker and auto-check forwarded news
- React to forwarded news with thumbs up/down and explanation when false

## Testing
- `pytest`
- `python -m py_compile enkibot/modules/fact_check.py enkibot/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68984d5b0628832a85ad229f11b99196