### PR TITLE
Log karma reactions via database procedure

### DIFF
--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -729,6 +729,19 @@ class TelegramHandlerService:
         if not reaction_update or not reaction_update.new_reaction:
             return
         emoji = reaction_update.new_reaction[0].emoji
+        try:
+            msg = getattr(reaction_update, "message", None)
+            rater = getattr(reaction_update, "user", None)
+            if msg and msg.from_user and rater:
+                await self.karma_manager.record_reaction_event(
+                    chat_id=update.effective_chat.id,
+                    msg_id=msg.message_id,
+                    target_user_id=msg.from_user.id,
+                    rater_user_id=rater.id,
+                    emoji=emoji,
+                )
+        except Exception as exc:
+            logger.error(f"Karma reaction logging failed: {exc}")
         handler = self.reaction_handlers.get(emoji)
         if handler:
             await handler(update, context)

--- a/enkibot/modules/karma_manager.py
+++ b/enkibot/modules/karma_manager.py
@@ -73,6 +73,31 @@ class KarmaManager:
             return self.config.emoji_map["low_quality"], "low_quality"
         return None
 
+    async def record_reaction_event(
+        self,
+        chat_id: int,
+        msg_id: int,
+        target_user_id: int,
+        rater_user_id: int,
+        emoji: str,
+    ) -> None:
+        """Send reaction events to the SQL procedure for persistence."""
+        if target_user_id == rater_user_id:
+            return
+        query = (
+            "EXEC dbo.usp_RecordKarmaEvent "
+            "@chat_id=?, @msg_id=?, @target_user_id=?, @rater_user_id=?, @emoji=?, @now=?"
+        )
+        params = (
+            chat_id,
+            msg_id,
+            target_user_id,
+            rater_user_id,
+            emoji,
+            datetime.utcnow(),
+        )
+        await self.db_manager.execute_query(query, params, commit=True)
+
     async def handle_text_vote(
         self, giver_id: int, receiver_id: int, chat_id: int, message_text: str
     ) -> Optional[str]:


### PR DESCRIPTION
## Summary
- add `record_reaction_event` in `KarmaManager` to invoke SQL proc `usp_RecordKarmaEvent`
- record message reactions in `TelegramHandlerService.reaction_router`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898614d26b4832a939417ea2b0b3b01