### PR TITLE
feat: add book quote fact checking track

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ EnkiBot is an intelligent and adaptable Telegram assistant designed for rich, co
 * **Administrative Moderation Tools**: one-tap ban/mute/warn commands with case logging, notes and reversible actions to keep chats civil.
 * **NSFW Image Filtering**: optional NudeNet-based scanner that removes high-risk images. Admins can toggle filtering and adjust per-chat sensitivity via `/nsfw_threshold`.
 * **(Planned) Darwinian Self-Improvement**: The project includes a foundational structure and conceptual plan for future integration of self-rewriting code and evolutionary capabilities, inspired by concepts like the Darwin Gödel Machine, aiming for autonomous advancement of the bot's Python modules and LLM prompts.
-* **Fact Checking Skeleton**: initial implementation of a fact checking subsystem with `/factcheck` command, satire detection hooks and admin configuration placeholders.
+* **Fact Checking Framework**: supports news and book‑quote verification via `/factcheck`, with satire detection hooks and admin configuration placeholders.
 * **Two-Tier Local Model Support**:
     * Optional router for fully local inference using `llama.cpp` compatible models.
     * Tier A: fast 7–8B models (e.g., Mistral‑7B or Llama‑3‑8B).

--- a/docs/news_only_fact_checking.md
+++ b/docs/news_only_fact_checking.md
@@ -1,6 +1,6 @@
-# News‑Only Fact‑Checking — Oracle‑Based Deep Research (o3/o4‑mini + GPT‑4o)
+# News & Book‑Quote Fact‑Checking — Oracle‑Based Deep Research (o3 + GPT‑4o)
 
-This document defines a **best‑of‑the‑best** mechanism for fact‑checking **forwarded news** in Telegram chats. The bot itself **never decides truth**. It orchestrates deep‑search **oracles** and reports their evaluations, with transparent sources and confidence.
+This document defines a **best‑of‑the‑best** mechanism for fact‑checking **forwarded news** and **book quotations** in Telegram chats. The bot itself **never decides truth**. It orchestrates deep‑search **oracles** and reports their evaluations, with transparent sources and confidence.
 
 > **Model routing rules** (built‑in):
 >
@@ -13,6 +13,7 @@ This document defines a **best‑of‑the‑best** mechanism for fact‑checking
 ## 0) Trust Boundary
 
 * **News‑only:** The pipeline first decides whether a forward is *news*. Non‑news (jokes, ads, memes, personal notes) are ignored.
+* **Book quotes:** Forwards that contain book‑like quotations are routed to a quote verification track.
 * **Oracle‑based:** Truth assessments come from **external providers** (search/fact‑check/news APIs). The bot/LLM may *synthesize* but **must not invent** a verdict; it **reports** provider findings and consensus/disagreement.
 * **Explainable:** Every card shows provider names, timestamps, links/snapshots, and confidence *as reported by providers*.
 
@@ -181,6 +182,14 @@ archive.snapshot: {"url":"string"}
 * **Disagreement rate** and time to consensus.
 * **Latency P50/P95** end‑to‑end.
 * **Appeal outcomes** (when users submit counter‑evidence).
+
+---
+
+## Book‑Quote Verification Track
+
+* **Quote Gate**: detects book-like quotations (quotes plus attributions, page numbers, or scanned pages).
+* **Search Oracles**: bibliographic catalogs, quote-investigation sites, and public domain editions.
+* **Output**: original passage (≤200 chars) with edition/page/translator and stance (accurate, misquote, misattrib, unverified).
 
 ---
 


### PR DESCRIPTION
## Summary
- extend fact checker to handle book quotes alongside news, adding a quote gate and dedicated LLM prompts
- log gate probabilities and fact check runs in the database with track info and book tables
- document the new quote verification flow and mention it in the README

## Testing
- `python -m py_compile enkibot/modules/fact_check.py enkibot/utils/database.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898697151a8832a96db06cd999870e7