### PR TITLE
feat: add memory evidence and persona tables

### DIFF
--- a/docs/memory_portrait_tables.md
+++ b/docs/memory_portrait_tables.md
@@ -1,0 +1,49 @@
+# Memory and Portrait Tables
+
+This document describes additional tables used to capture evidence for memory answers
+and to version user psychological portraits.
+
+## `answer_evidence`
+Stores high-level information about evidence gathered for a bot answer.
+
+```sql
+CREATE TABLE answer_evidence (
+  answer_id BIGINT IDENTITY PRIMARY KEY,
+  chat_id   BIGINT NOT NULL,
+  asked_by  BIGINT NOT NULL,
+  intent    NVARCHAR(32) NOT NULL,
+  query_text NVARCHAR(MAX) NULL,
+  lang      NVARCHAR(8) NULL,
+  created_at DATETIME2(3) NOT NULL DEFAULT SYSUTCDATETIME()
+);
+```
+
+## `answer_evidence_items`
+Links a particular answer to the messages that supported it.
+
+```sql
+CREATE TABLE answer_evidence_items (
+  answer_id BIGINT NOT NULL,
+  message_id BIGINT NOT NULL,
+  rank INT NOT NULL,
+  snippet NVARCHAR(MAX) NULL,
+  reason NVARCHAR(64) NULL,
+  PRIMARY KEY(answer_id, message_id)
+);
+```
+
+## `user_persona_versions`
+Maintains versioned Markdown portraits and traits for each user.
+
+```sql
+CREATE TABLE user_persona_versions (
+  chat_id BIGINT NOT NULL,
+  user_id BIGINT NOT NULL,
+  version INT NOT NULL,
+  created_at DATETIME2(3) NOT NULL DEFAULT SYSUTCDATETIME(),
+  portrait_md NVARCHAR(MAX) NOT NULL,
+  traits_json NVARCHAR(MAX) NOT NULL,
+  signals_json NVARCHAR(MAX) NULL,
+  PRIMARY KEY(chat_id, user_id, version)
+);
+```


### PR DESCRIPTION
## Summary
- persist answer evidence and persona versions in database
- document schema for new memory and portrait tables

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68986beb2e88832abe11193736dfdfe6