### PR TITLE
Fix karma vote handling to record delta correctly

### DIFF
--- a/enkibot/core/telegram_handlers.py
+++ b/enkibot/core/telegram_handlers.py
@@ -684,11 +684,12 @@ class TelegramHandlerService:
         receiver = message.reply_to_message.from_user if message.reply_to_message else None
         if not giver or not receiver:
             return False
-        result = await self.karma_manager.handle_text_vote(
+        vote_result = await self.karma_manager.handle_text_vote(
             giver.id, receiver.id, message.chat_id, message.text
         )
-        if result is None:
+        if vote_result is None:
             return False
+        result, delta = vote_result
         receiver_display = f"@{receiver.username}" if receiver.username else receiver.first_name
         if result == "self_karma_error":
             await message.reply_text("🤷 You can't vote on yourself.")
@@ -697,7 +698,6 @@ class TelegramHandlerService:
         elif result == "karma_changed_success":
             stats = await self.karma_manager.get_user_stats(receiver.id)
             total = stats["received"] if stats else 0
-            delta = self.karma_manager.parse_vote_token(message.text)
             sign = "+" if delta > 0 else ""
             await message.reply_text(f"{sign}{delta} to {receiver_display} (total {total:+})")
         return True

--- a/enkibot/modules/karma_manager.py
+++ b/enkibot/modules/karma_manager.py
@@ -100,13 +100,19 @@ class KarmaManager:
 
     async def handle_text_vote(
         self, giver_id: int, receiver_id: int, chat_id: int, message_text: str
-    ) -> Optional[str]:
-        """Parse a message for karma tokens and apply the change."""
+    ) -> Optional[Tuple[str, float]]:
+        """Parse a message for karma tokens and apply the change.
+
+        Returns a tuple of (result, base_weight) on success so callers can
+        report the delta without reparsing the message.  If the message does
+        not contain a valid karma token, returns ``None``.
+        """
         parsed = self.parse_vote_token(message_text)
         if not parsed:
             return None
         base, tag = parsed
-        return await self.change_karma(giver_id, receiver_id, chat_id, base, tag)
+        result = await self.change_karma(giver_id, receiver_id, chat_id, base, tag)
+        return result, base
 
     async def _get_rater_trust(self, chat_id: int, user_id: int) -> float:
         """Fetch rater trust from the trust_table if present."""


### PR DESCRIPTION
## Summary
- return vote status and weight from `handle_text_vote`
- use returned weight in Telegram handler to avoid tuple comparisons

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68986fb61c80832a82856163acc26668