### PR TITLE
Replace DuckDuckGo search with OpenAI web search

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,6 @@ The project is organized into logical modules:
     If you plan to run the local two-tier models you also need:
     ```txt
     llama-cpp-python
-    duckduckgo-search
     trafilatura
     faiss-cpu
     sentence-transformers
@@ -207,7 +206,7 @@ The project is organized into logical modules:
    ```bash
    TELEGRAM_BOT_TOKEN=... python -m enkibot.local_telegram_bot
    ```
-   Normal messages go to the fast 7–8B model. Use `/deep` to force the 70B/72B model or `/web <query>` to run a duckduckgo search and summarise the top pages with citations.
+   Normal messages go to the fast 7–8B model. Use `/deep` to force the 70B/72B model or `/web <query>` to run a web search via the OpenAI Responses API and summarise the top pages with citations.
 4. (Optional) For Retrieval‑Augmented Generation, index your own documents:
    ```python
    from enkibot.modules.rag_service import RAGService

--- a/enkibot/local_telegram_bot.py
+++ b/enkibot/local_telegram_bot.py
@@ -28,8 +28,8 @@ commands:
 
 ``/fast`` – use the 7–8B model directly.
 ``/deep`` – force the 70B/72B model.
-``/web``  – perform a duckduckgo search, fetch top pages and summarise with
-            citations via the fast model.
+``/web``  – perform a web search via the OpenAI responses API and
+            summarise the top pages with citations using the fast model.
 
 Any other message goes through :class:`~enkibot.modules.model_router.ModelRouter`
 which escalates to the deep model when needed.


### PR DESCRIPTION
## Summary
- replace DuckDuckGo-based search with OpenAI Responses API web search
- update local tooling and docs to reflect new OpenAI web search
- remove DuckDuckGo references from fact-checking utilities

## Testing
- `python -m py_compile enkibot/modules/primary_source_hunter.py enkibot/modules/web_tool.py enkibot/local_telegram_bot.py enkibot/modules/fact_check.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898754ebdcc832ab12b5d17ceead596