### PR TITLE
Add Unicode normalization helper to fact checker

### DIFF
--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -52,6 +52,7 @@ import json
 import openai
 from .. import config
 from ..utils.database import DatabaseManager
+from ..utils.lang_router import normalize as normalize_unicode
 
 if TYPE_CHECKING:  # pragma: no cover - only for type hints
     from .primary_source_hunter import PrimarySourceHunter, SourceHit
@@ -359,6 +360,8 @@ URL_RE = re.compile(r"https?://\S+", re.I)
 
 
 def normalize_text(s: str) -> str:
+    """Apply Unicode normalization and collapse whitespace."""
+    s = normalize_unicode(s)
     return re.sub(r"\s+", " ", s).strip()
 
 

--- a/enkibot/utils/lang_router.py
+++ b/enkibot/utils/lang_router.py
@@ -1,0 +1,12 @@
+import re
+import unicodedata
+
+
+def normalize(s: str) -> str:
+    """Normalize unicode string and drop zero-width characters.
+
+    This utility applies NFKC normalization and removes common zero-width
+    characters that may cause message truncation or other subtle bugs.
+    """
+    s = unicodedata.normalize("NFKC", s or "")
+    return re.sub(r"[\u200B\u200C\u200D\u200E\u2060]", "", s).strip()


### PR DESCRIPTION
## Summary
- add a shared utility for Unicode normalization that removes zero-width characters
- normalize fact-checker claim text using the new helper

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68987d278a90832a8ae5ecf1392ed468