### PR TITLE
Improve Russian handling and quote detection

### DIFF
--- a/enkibot/core/language_service.py
+++ b/enkibot/core/language_service.py
@@ -304,10 +304,17 @@ class LanguageService:
             logger.info(f"LLM confidently detected primary lang '{llm_detected_primary_lang}' (conf: {llm_detected_confidence:.2f}).")
             final_candidate_lang_code = llm_detected_primary_lang
         else:
-            if llm_detected_primary_lang: 
+            if llm_detected_primary_lang:
                  logger.warning(f"LLM detected lang '{llm_detected_primary_lang}' but confidence ({llm_detected_confidence:.2f}) "
                                f"< threshold ({LLM_LANG_DETECTION_CONFIDENCE_THRESHOLD}). Using current/default: {final_candidate_lang_code}")
-            # If no LLM detection or low confidence, final_candidate_lang_code remains as initialized (current or default)
+            # If no LLM detection or low confidence, use simple heuristics based
+            # on the characters present in the message. This ensures languages
+            # like Russian are still recognised even when the LLM is
+            # unavailable.
+            if re.search(r"[\u0400-\u04FF]", aggregated_text_for_llm_prompt_check):
+                final_candidate_lang_code = "ru"
+            elif re.search(r"[A-Za-z]", aggregated_text_for_llm_prompt_check):
+                final_candidate_lang_code = "en"
 
         unsupported_codes = ("", "und", "undefined", "none")
         if final_candidate_lang_code in unsupported_codes:

--- a/tests/test_fact_check_quotes.py
+++ b/tests/test_fact_check_quotes.py
@@ -1,0 +1,22 @@
+import os
+import sys
+import types
+import pytest
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+
+from enkibot.modules.fact_check import QuoteGate, FactChecker
+
+
+def test_quote_gate_ignores_single_word():
+    qg = QuoteGate()
+    score = asyncio.run(qg.predict('Мошенники сказали: «Силовики»'))
+    assert score < 0.5
+
+
+def test_extract_quote_ignores_single_word():
+    fc = FactChecker()
+    assert asyncio.run(fc.extract_quote('«Силовики»')) is None
+    assert asyncio.run(fc.extract_quote('«Лиса и ежик шли по лесу»')) is not None

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import types
+import pytest
+import asyncio
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+
+from enkibot.core.language_service import LanguageService
+
+
+class DummyLLM:
+    async def call_openai_llm(self, *args, **kwargs):
+        return None
+
+    def is_provider_configured(self, *args, **kwargs):
+        return False
+
+
+class DummyDB:
+    async def get_recent_chat_texts(self, chat_id, limit):
+        return []
+
+
+def test_russian_heuristic_detection():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('энки расскажи сказку', chat_id=None))
+    assert ls.current_lang == 'ru'


### PR DESCRIPTION
## Summary
- Ignore short single-word citations so fact-checking doesn't trigger on words like «Силовики»
- Add heuristic language detection for Russian when LLM language classification is unavailable
- Test quote gate and language detection behavior

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898866a6234832aa583096ba344a556