### PR TITLE
Improve language detection and localize fact-check hints

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -132,6 +132,7 @@ class EnkiBotApplication:
             satire_detector=SatireDetector(_default_fact_cfg),
             cfg_reader=_default_fact_cfg,
             db_manager=self.db_manager,
+            language_service=self.language_service,
         )
         self.fact_check_bot.register()
 

--- a/enkibot/lang/en.json
+++ b/enkibot/lang/en.json
@@ -126,7 +126,11 @@
     "video_message_received": "Received your video note. Processing...",
     "video_transcription_failed": "Sorry, I couldn't understand the audio in that video.",
     "video_transcription_header": "Video transcription:",
-    "video_translation_header": "Video translation (Russian):"
+    "video_translation_header": "Video translation (Russian):",
+    "show_sources_button": "Sources",
+    "factcheck_hint_book": "Check quote?",
+    "factcheck_hint_news": "Check as news?",
+    "top_sources_header": "Top sources:"
   },
   "weather_conditions_map": {
     "clear_sky": "Clear sky",

--- a/enkibot/lang/ru.json
+++ b/enkibot/lang/ru.json
@@ -127,7 +127,11 @@
     "video_message_received": "Получил ваше видео сообщение. Обрабатываю...",
     "video_transcription_failed": "Извините, я не смог разобрать аудио в этом видео.",
     "video_transcription_header": "Транскрипция видео:",
-    "video_translation_header": "Перевод видео (на русский):"
+    "video_translation_header": "Перевод видео (на русский):",
+    "show_sources_button": "Показать источники",
+    "factcheck_hint_book": "Проверить цитату?",
+    "factcheck_hint_news": "Проверить как новость?",
+    "top_sources_header": "Главные источники:"
   },
   "weather_conditions_map": {
     "clear_sky": "Ясно",

--- a/enkibot/lang/uk.json
+++ b/enkibot/lang/uk.json
@@ -126,7 +126,11 @@
     "video_message_received": "Я отримав ваше відео -повідомлення. Я обробляю ...",
     "video_transcription_failed": "Вибачте, я не міг розібратися з аудіо у цьому відео.",
     "video_transcription_header": "Відео транскрипція:",
-    "video_translation_header": "Переклад відео (на російську мову):"
+    "video_translation_header": "Переклад відео (на російську мову):",
+    "show_sources_button": "Джерела",
+    "factcheck_hint_book": "Перевірити цитату?",
+    "factcheck_hint_news": "Перевірити як новину?",
+    "top_sources_header": "Основні джерела:"
   },
   "weather_conditions_map": {
     "clear_sky": "Чіткий",

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -27,3 +27,46 @@ def test_russian_heuristic_detection():
     ls = LanguageService(DummyLLM(), DummyDB())
     asyncio.run(ls.determine_language_context('энки расскажи сказку', chat_id=None))
     assert ls.current_lang == 'ru'
+
+
+def test_ukrainian_detection():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('привіт, як справи?', chat_id=None))
+    assert ls.current_lang == 'uk'
+
+
+def test_english_detection():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('hello there', chat_id=None))
+    assert ls.current_lang == 'en'
+
+
+def test_code_switch_prefers_cyrillic():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('привет show weather', chat_id=None))
+    assert ls.current_lang == 'ru'
+
+
+def test_transliteration_detection():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('privet, kak dela?', chat_id=None))
+    assert ls.current_lang == 'ru'
+
+
+def test_short_inputs():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('да', chat_id=None))
+    assert ls.current_lang == 'ru'
+    asyncio.run(ls.determine_language_context('ok', chat_id=None))
+    assert ls.current_lang == 'en'
+
+
+class DummyDBHistory:
+    async def get_recent_chat_texts(self, chat_id, limit):
+        return ['Новость про Київ']
+
+
+def test_english_reply_to_russian_history():
+    ls = LanguageService(DummyLLM(), DummyDBHistory())
+    asyncio.run(ls.determine_language_context('Where is the proof?', chat_id=1))
+    assert ls.current_lang == 'en'


### PR DESCRIPTION
## Summary
- Enhance language detection: handle Ukrainian, transliterated Russian, code-switching, and short inputs
- Localize fact-check hints and source headers with language-specific strings
- Wire language service into fact-check bot for per-message localization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68988a192864832a8dbb82e1d1d1ad7b