### PR TITLE
Improve language detection heuristics and test stubs

### DIFF
--- a/tests/test_fact_check_quotes.py
+++ b/tests/test_fact_check_quotes.py
@@ -6,6 +6,48 @@ import asyncio
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+sys.modules.setdefault("httpx", types.SimpleNamespace())
+sys.modules.setdefault("openai", types.SimpleNamespace())
+
+
+class DummyFilter:
+    def __and__(self, other):
+        return self
+
+    def __or__(self, other):
+        return self
+
+    def __invert__(self):
+        return self
+
+
+dummy_filters = types.SimpleNamespace(
+    TEXT=DummyFilter(),
+    COMMAND=DummyFilter(),
+    CAPTION=DummyFilter(),
+)
+
+sys.modules.setdefault(
+    "telegram",
+    types.SimpleNamespace(
+        InlineKeyboardButton=object,
+        InlineKeyboardMarkup=object,
+        Update=object,
+        Message=object,
+    ),
+)
+
+sys.modules.setdefault(
+    "telegram.ext",
+    types.SimpleNamespace(
+        Application=object,
+        CallbackQueryHandler=object,
+        CommandHandler=object,
+        ContextTypes=types.SimpleNamespace(DEFAULT_TYPE=object),
+        MessageHandler=object,
+        filters=dummy_filters,
+    ),
+)
 
 from enkibot.modules.fact_check import QuoteGate, FactChecker
 

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -6,6 +6,9 @@ import asyncio
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+sys.modules.setdefault("telegram", types.SimpleNamespace(Update=object))
+sys.modules.setdefault("httpx", types.SimpleNamespace())
+sys.modules.setdefault("openai", types.SimpleNamespace())
 
 from enkibot.core.language_service import LanguageService
 
@@ -23,7 +26,20 @@ class DummyDB:
         return []
 
 
-def test_russian_heuristic_detection():
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("энки расскажи сказку", "ru"),
+        ("tell me a story", "en"),
+        ("енкі розкажи казку", "uk"),
+        ("privet, kak dela?", "ru"),
+        ("ok", "en"),
+        ("ок", "ru"),
+        ("да", "ru"),
+    ],
+)
+def test_language_detection_cases(text, expected):
     ls = LanguageService(DummyLLM(), DummyDB())
-    asyncio.run(ls.determine_language_context('энки расскажи сказку', chat_id=None))
-    assert ls.current_lang == 'ru'
+    asyncio.run(ls.determine_language_context(text, chat_id=None))
+    assert ls.current_lang == expected


### PR DESCRIPTION
## Summary
- Handle missing telegram dependency in language service
- Add heuristics for Ukrainian text and transliterated Russian
- Stub external modules in tests and expand language detection coverage

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68988a192864832a8dbb82e1d1d1ad7b