### PR TITLE
Improve language detection and localize fact-check hints

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -132,6 +132,7 @@ class EnkiBotApplication:
             satire_detector=SatireDetector(_default_fact_cfg),
             cfg_reader=_default_fact_cfg,
             db_manager=self.db_manager,
+            language_service=self.language_service,
         )
         self.fact_check_bot.register()
 

--- a/enkibot/lang/en.json
+++ b/enkibot/lang/en.json
@@ -126,7 +126,10 @@
     "video_message_received": "Received your video note. Processing...",
     "video_transcription_failed": "Sorry, I couldn't understand the audio in that video.",
     "video_transcription_header": "Video transcription:",
-    "video_translation_header": "Video translation (Russian):"
+    "video_translation_header": "Video translation (Russian):",
+    "hint_check_quote": "Check quote?",
+    "hint_check_news": "Check as news?",
+    "button_show_sources": "Sources"
   },
   "weather_conditions_map": {
     "clear_sky": "Clear sky",

--- a/enkibot/lang/ru.json
+++ b/enkibot/lang/ru.json
@@ -127,7 +127,10 @@
     "video_message_received": "Получил ваше видео сообщение. Обрабатываю...",
     "video_transcription_failed": "Извините, я не смог разобрать аудио в этом видео.",
     "video_transcription_header": "Транскрипция видео:",
-    "video_translation_header": "Перевод видео (на русский):"
+    "video_translation_header": "Перевод видео (на русский):",
+    "hint_check_quote": "Проверить цитату?",
+    "hint_check_news": "Проверить как новость?",
+    "button_show_sources": "Показать источники"
   },
   "weather_conditions_map": {
     "clear_sky": "Ясно",

--- a/enkibot/lang/uk.json
+++ b/enkibot/lang/uk.json
@@ -126,7 +126,10 @@
     "video_message_received": "Я отримав ваше відео -повідомлення. Я обробляю ...",
     "video_transcription_failed": "Вибачте, я не міг розібратися з аудіо у цьому відео.",
     "video_transcription_header": "Відео транскрипція:",
-    "video_translation_header": "Переклад відео (на російську мову):"
+    "video_translation_header": "Переклад відео (на російську мову):",
+    "hint_check_quote": "Перевірити цитату?",
+    "hint_check_news": "Перевірити як новину?",
+    "button_show_sources": "Джерела"
   },
   "weather_conditions_map": {
     "clear_sky": "Чіткий",

--- a/enkibot/lang/x-ps.json
+++ b/enkibot/lang/x-ps.json
@@ -126,7 +126,10 @@
     "video_message_received": "[ Received your video note. Processing... ]",
     "video_transcription_failed": "[ Sorry, I couldn't understand the audio in that video. ]",
     "video_transcription_header": "[ Video transcription: ]",
-    "video_translation_header": "[ Video translation (Russian): ]"
+    "video_translation_header": "[ Video translation (Russian): ]",
+    "hint_check_quote": "[ Check quote? ]",
+    "hint_check_news": "[ Check as news? ]",
+    "button_show_sources": "[ Sources ]"
   },
   "weather_conditions_map": {
     "clear_sky": "[ Clear sky* ]",

--- a/tests/test_language_detection.py
+++ b/tests/test_language_detection.py
@@ -27,3 +27,41 @@ def test_russian_heuristic_detection():
     ls = LanguageService(DummyLLM(), DummyDB())
     asyncio.run(ls.determine_language_context('энки расскажи сказку', chat_id=None))
     assert ls.current_lang == 'ru'
+
+
+def test_english_detection():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('hello how are you', chat_id=None))
+    assert ls.current_lang == 'en'
+
+
+def test_ukrainian_detection():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('привіт, як справи?', chat_id=None))
+    assert ls.current_lang == 'uk'
+
+
+def test_transliterated_russian_detection():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('privet, kak dela?', chat_id=None))
+    assert ls.current_lang == 'ru'
+
+
+def test_latest_message_priority_over_context():
+    class ContextDB(DummyDB):
+        async def get_recent_chat_texts(self, chat_id, limit):
+            return ['привет из прошлого']
+
+    ls = LanguageService(DummyLLM(), ContextDB())
+    asyncio.run(ls.determine_language_context('ok thanks', chat_id=1))
+    assert ls.current_lang == 'en'
+
+
+def test_short_inputs():
+    ls = LanguageService(DummyLLM(), DummyDB())
+    asyncio.run(ls.determine_language_context('да', chat_id=None))
+    assert ls.current_lang == 'ru'
+    asyncio.run(ls.determine_language_context('ok', chat_id=None))
+    assert ls.current_lang == 'en'
+    asyncio.run(ls.determine_language_context('ок', chat_id=None))
+    assert ls.current_lang == 'ru'


### PR DESCRIPTION
## Summary
- Prioritize latest message language, handle Ukrainian and transliterated Russian, and fall back to user language when ambiguous
- Localize fact-check hints and “Show sources” button using language packs
- Add comprehensive language detection tests for edge cases

## Testing
- `pytest`
- `python scripts/i18n_coverage.py`

------
https://chatgpt.com/codex/tasks/task_e_6898b812d39c832aaaa84a570a37009f