### PR TITLE
Log missing i18n keys and tighten coverage checks

### DIFF
--- a/enkibot/core/language_service.py
+++ b/enkibot/core/language_service.py
@@ -440,9 +440,19 @@ class LanguageService:
                 lang_tried = secondary_fallback_lang
                 raw_string = self.response_strings.get(secondary_fallback_lang, {}).get(key)
 
-        if raw_string is None: 
-            if default_value is not None: raw_string = default_value
-            else: logger.error(f"Response string for key '{key}' ultimately not found. Using placeholder."); raw_string = f"[[Missing response: {key}]]"
+        if raw_string is None:
+            if default_value is not None:
+                raw_string = default_value
+            else:
+                logger.error(
+                    f"Response string for key '{key}' ultimately not found",
+                    extra={
+                        "event_type": "i18n.missing_key",
+                        "key": key,
+                        "lang": lang_tried,
+                    },
+                )
+                raw_string = f"[[Missing response: {key}]]"
         
         try:
             return raw_string.format(**kwargs) if kwargs else raw_string

--- a/scripts/i18n_coverage.py
+++ b/scripts/i18n_coverage.py
@@ -33,7 +33,7 @@ def _flatten(d: Dict, prefix: str = "") -> Iterable[str]:
             yield new_key
 
 
-def _compare(locales: Dict[str, Dict]) -> None:
+def _compare(locales: Dict[str, Dict]) -> bool:
     key_sets: Dict[str, Set[str]] = {
         lang: set(_flatten(data)) for lang, data in locales.items()
     }
@@ -55,6 +55,7 @@ def _compare(locales: Dict[str, Dict]) -> None:
                     print("  ", k)
     if ok:
         print("All locale files share the same key set.")
+    return ok
 
 
 def _pseudo_localize(base: Dict) -> Dict:
@@ -87,7 +88,8 @@ def main() -> None:
         print("No locale files found in", LANG_DIR, file=sys.stderr)
         sys.exit(1)
 
-    _compare(locales)
+    if not _compare(locales):
+        sys.exit(1)
 
     if args.pseudo:
         base = locales.get("en")

--- a/tests/test_i18n_missing_key_logging.py
+++ b/tests/test_i18n_missing_key_logging.py
@@ -1,0 +1,18 @@
+import os
+import sys
+import types
+import logging
+from types import SimpleNamespace
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+
+from enkibot.core.language_service import LanguageService
+
+
+def test_missing_key_logs_event(caplog):
+    ls = LanguageService(SimpleNamespace(), SimpleNamespace())
+    ls.current_response_strings = {}
+    with caplog.at_level(logging.ERROR):
+        ls.get_response_string("nonexistent")
+    assert any(getattr(r, "event_type", "") == "i18n.missing_key" for r in caplog.records)


### PR DESCRIPTION
## Summary
- log missing localization keys with `event_type=i18n.missing_key`
- fail the i18n coverage script when key sets diverge
- test that missing localization keys are reported

## Testing
- `python scripts/i18n_coverage.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898ce22dc60832aa647b349a4cfd768