### PR TITLE
Normalize bot aliases for reliable Russian triggering

### DIFF
--- a/enkibot/utils/trigger_extractor.py
+++ b/enkibot/utils/trigger_extractor.py
@@ -22,11 +22,13 @@ def extract_assistant_prompt(text: str, aliases: Iterable[str], bot_username: st
         bot_username: Telegram username of the bot, if available.
     """
     t = _normalize(text)
-    alias_list = {a.lower() for a in aliases if a}
-    alias_list.update({a.lower() for a in NAME_ALIASES_DEFAULT})
+
+    # Normalize and case-fold aliases for robust matching across scripts
+    alias_list = {_normalize(a).casefold() for a in aliases if a}
+    alias_list.update({_normalize(a).casefold() for a in NAME_ALIASES_DEFAULT})
     patterns = [re.escape(a) for a in alias_list]
     if bot_username:
-        bot_username = bot_username.lower()
+        bot_username = _normalize(bot_username).casefold()
         patterns.append(re.escape(bot_username))
         patterns.append("@" + re.escape(bot_username))
         if not bot_username.endswith("bot"):

--- a/tests/test_trigger_extraction.py
+++ b/tests/test_trigger_extraction.py
@@ -38,3 +38,10 @@ def test_latin_name():
     triggered, content, alias = extract_assistant_prompt("Enki, write a poem", ALIASES)
     assert triggered
     assert content == "write a poem"
+
+
+def test_alias_with_zero_width_space_in_config():
+    custom_aliases = ["бот\u200b"]
+    triggered, content, alias = extract_assistant_prompt("бот расскажи сказку", custom_aliases)
+    assert triggered
+    assert content == "расскажи сказку"


### PR DESCRIPTION
## Summary
- Normalize and casefold bot aliases before pattern generation to handle Unicode variations and stray zero-width characters
- Add regression test covering alias configured with a hidden zero-width space

## Testing
- `pytest tests/test_language_detection.py tests/test_trigger_extraction.py`


------
https://chatgpt.com/codex/tasks/task_e_6898d070cf48832aa155c819c8242753