### PR TITLE
Detect message language before spam checks

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -82,6 +82,7 @@ class EnkiBotApplication:
         self.spam_detector = SpamDetector(
             self.llm_services,
             self.db_manager,
+            self.language_service,
             enabled=config.ENABLE_SPAM_DETECTION,
         )
         self.stats_manager = StatsManager(self.db_manager)


### PR DESCRIPTION
## Summary
- integrate `LanguageService` into `SpamDetector`
- detect message language before applying spam heuristics or OpenAI moderation
- inject `LanguageService` when constructing the spam detector

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898d3936838832a842760a3daaa848d