### PR TITLE
Use deep research model with locale-aware fact check responses

### DIFF
--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -498,10 +498,17 @@ class FactChecker:
                 sources=[],
             )
 
+        lang_name = {
+            "ru": "Russian",
+            "uk": "Ukrainian",
+            "en": "English",
+        }.get(claim.lang or "", "the original language of the claim")
+
         system_prompt = (
             "You are a fact-checking assistant. Decide if the claim is true, false, "
             "needs_context, or unverified. If unsure, respond with unverified. "
-            "Return a JSON object with keys 'label', 'confidence' (0-1), and 'summary'."
+            "Return a JSON object with keys 'label', 'confidence' (0-1), and 'summary' in "
+            f"{lang_name}."
         )
         user_prompt = f"Claim: {claim.text_orig}"
         messages = [
@@ -509,13 +516,15 @@ class FactChecker:
             {"role": "user", "content": user_prompt},
         ]
 
-        debug.append(f"LLM model: {getattr(self.llm_services, 'openai_model_id', 'unknown')}")
+        debug.append(
+            f"LLM model: {getattr(self.llm_services, 'openai_deep_research_model_id', 'unknown')}"
+        )
         debug.append(f"System prompt: {system_prompt}")
         debug.append(f"User prompt: {user_prompt}")
 
         try:
-            completion = await self.llm_services.call_openai_llm(
-                messages, temperature=0.0, max_tokens=300
+            completion = await self.llm_services.call_openai_deep_research(
+                messages, max_output_tokens=300
             )
             logger.debug("LLM verdict: received completion %r", completion)
             debug.append(f"Raw response: {completion}")

--- a/tests/test_fact_check_claim_lang.py
+++ b/tests/test_fact_check_claim_lang.py
@@ -5,6 +5,27 @@ import types
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+filters_stub = types.SimpleNamespace(TEXT=1, COMMAND=2, CAPTION=4)
+sys.modules.setdefault(
+    "telegram",
+    types.SimpleNamespace(
+        InlineKeyboardButton=object,
+        InlineKeyboardMarkup=object,
+        Update=object,
+        Message=object,
+    ),
+)
+sys.modules.setdefault(
+    "telegram.ext",
+    types.SimpleNamespace(
+        Application=object,
+        CallbackQueryHandler=object,
+        CommandHandler=object,
+        ContextTypes=object,
+        MessageHandler=object,
+        filters=filters_stub,
+    ),
+)
 
 from enkibot.modules.fact_check import FactChecker
 

--- a/tests/test_fact_check_llm_deep_research.py
+++ b/tests/test_fact_check_llm_deep_research.py
@@ -1,0 +1,67 @@
+import asyncio
+import json
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+filters_stub = types.SimpleNamespace(TEXT=1, COMMAND=2, CAPTION=4)
+sys.modules.setdefault(
+    "telegram",
+    types.SimpleNamespace(
+        InlineKeyboardButton=object,
+        InlineKeyboardMarkup=object,
+        Update=object,
+        Message=object,
+    ),
+)
+sys.modules.setdefault(
+    "telegram.ext",
+    types.SimpleNamespace(
+        Application=object,
+        CallbackQueryHandler=object,
+        CommandHandler=object,
+        ContextTypes=object,
+        MessageHandler=object,
+        filters=filters_stub,
+    ),
+)
+
+from enkibot.modules.fact_check import FactChecker, Claim
+
+
+class DummyLLM:
+    def __init__(self):
+        self.deepr_called = False
+        self.llm_called = False
+        self.messages = None
+
+    async def call_openai_deep_research(self, messages, max_output_tokens=1000):
+        self.deepr_called = True
+        self.messages = messages
+        return json.dumps({
+            "label": "unverified",
+            "confidence": 0.0,
+            "summary": "пример",
+        })
+
+    async def call_openai_llm(self, *args, **kwargs):
+        self.llm_called = True
+        return None
+
+
+def test_llm_verdict_uses_deep_research_and_russian_summary():
+    dummy = DummyLLM()
+    fc = FactChecker(llm_services=dummy)
+    claim = Claim(
+        text_norm="Умер театральный режиссер Юрий Бутусов.",
+        text_orig="Умер театральный режиссер Юрий Бутусов.",
+        lang="ru",
+        urls=[],
+        hash="abc",
+    )
+    verdict = asyncio.run(fc._llm_verdict(claim, []))
+    assert dummy.deepr_called
+    assert not dummy.llm_called
+    assert "summary' in Russian" in dummy.messages[0]["content"]
+    assert verdict.summary == "пример"


### PR DESCRIPTION
## Summary
- Ensure fact check verdicts use OpenAI's deep research model with web search
- Tailor fact check summaries to the original claim's language
- Add regression test covering deep-research verdict language handling

## Testing
- `pytest tests/test_fact_check_claim_lang.py tests/test_fact_check_llm_deep_research.py -q`

------
https://chatgpt.com/codex/tasks/task_e_6899496bc134832a833ab1a5746907c9