### PR TITLE
Fix deep research tool type for OpenAI web search

### DIFF
--- a/enkibot/core/llm_services.py
+++ b/enkibot/core/llm_services.py
@@ -150,9 +150,9 @@ class LLMServices:
                                         max_output_tokens: int = 1000) -> Optional[str]:
         """Call OpenAI's deep research model with web search enabled.
 
-        This uses the Responses API so the model can issue web_search tool calls
-        when checking claims. It returns the aggregated text response or
-        ``None`` if the call fails.
+        This uses the Responses API so the model can issue `web_search_preview`
+        tool calls when checking claims. It returns the aggregated text response
+        or ``None`` if the call fails.
         """
         if not self.is_provider_configured("openai"):
             logger.warning("OpenAI client not initialized or API key missing. Cannot make deep research call.")
@@ -162,7 +162,7 @@ class LLMServices:
             response = await self.openai_async_client.responses.create(
                 model=self.openai_deep_research_model_id,
                 input=messages,
-                tools=[{"type": "web_search"}],
+                tools=[{"type": "web_search_preview"}],
                 tool_choice="auto",
                 reasoning={"effort": "medium"},
                 max_output_tokens=max_output_tokens,

--- a/enkibot/modules/primary_source_hunter.py
+++ b/enkibot/modules/primary_source_hunter.py
@@ -107,7 +107,7 @@ class PrimarySourceHunter:
         try:
             resp = await self.client.responses.create(
                 model=self.model_id,
-                tools=[{"type": "web_search"}],
+                tools=[{"type": "web_search_preview"}],
                 tool_choice="auto",
                 reasoning={"effort": "high"},
                 instructions=(

--- a/enkibot/modules/web_tool.py
+++ b/enkibot/modules/web_tool.py
@@ -49,7 +49,7 @@ def web_research(query: str, k: int = 5) -> List[Dict[str, str]]:
     try:
         resp = client.responses.create(
             model=config.OPENAI_DEEP_RESEARCH_MODEL_ID,
-            tools=[{"type": "web_search"}],
+            tools=[{"type": "web_search_preview"}],
             tool_choice="auto",
             reasoning={"effort": "medium"},
             instructions=(


### PR DESCRIPTION
## Summary
- Replace deprecated `web_search` tool with `web_search_preview` for OpenAI deep research calls
- Align primary source hunting and web research helpers with `web_search_preview`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68994cf905ec832a92d5439214429fc1