### PR TITLE
fix: update web search API parameters

### DIFF
--- a/enkibot/core/llm_services.py
+++ b/enkibot/core/llm_services.py
@@ -153,9 +153,9 @@ class LLMServices:
                                         max_output_tokens: int = 1000) -> Optional[str]:
         """Call OpenAI's deep research model with web search enabled.
 
-        This uses the Responses API so the model can issue `web_search_preview`
-        tool calls when checking claims. It returns the aggregated text response
-        or ``None`` if the call fails.
+        This uses the Responses API so the model can issue `web_search` tool
+        calls when checking claims. It returns the aggregated text response or
+        ``None`` if the call fails.
         """
         if not self.is_provider_configured("openai"):
             logger.warning("OpenAI client not initialized or API key missing. Cannot make deep research call.")
@@ -165,9 +165,8 @@ class LLMServices:
             response = await self.openai_async_client.responses.create(
                 model=self.openai_deep_research_model_id,
                 input=messages,
-                tools=[{"type": "web_search_preview"}],
+                tools=[{"type": "web_search"}],
                 tool_choice="auto",
-                reasoning={"effort": "medium"},
                 max_output_tokens=max_output_tokens,
             )
             latency = time.perf_counter() - start

--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -216,9 +216,8 @@ class OpenAIWebFetcher(Fetcher):
                 kwargs["extra_body"] = extra_body
             resp = await client.responses.create(
                 model=config.OPENAI_DEEP_RESEARCH_MODEL_ID,
-                tools=[{"type": "web_search_preview"}],
-                tool_choice={"type": "web_search_preview"},
-                reasoning={"effort": "medium"},
+                tools=[{"type": "web_search"}],
+                tool_choice={"type": "web_search"},
                 instructions="Return 3-6 sources as a JSON array with 'url' and 'title'.",
                 input=claim.text_norm,
                 **kwargs,
@@ -237,9 +236,8 @@ class OpenAIWebFetcher(Fetcher):
             try:
                 resp = await client.responses.create(
                     model=config.OPENAI_MODEL_ID,
-                    tools=[{"type": "web_search_preview"}],
-                    tool_choice={"type": "web_search_preview"},
-                    reasoning={"effort": "medium"},
+                    tools=[{"type": "web_search"}],
+                    tool_choice={"type": "web_search"},
                     instructions="Return 3-6 sources as a JSON array with 'url' and 'title'.",
                     input=claim.text_norm,
                     **kwargs,

--- a/enkibot/modules/primary_source_hunter.py
+++ b/enkibot/modules/primary_source_hunter.py
@@ -107,9 +107,8 @@ class PrimarySourceHunter:
         try:
             resp = await self.client.responses.create(
                 model=self.model_id,
-                tools=[{"type": "web_search_preview"}],
+                tools=[{"type": "web_search"}],
                 tool_choice="auto",
-                reasoning={"effort": "high"},
                 instructions=(
                     "You are a primary-source hunter. Always include 3-6 sources (at least 1 primary). "
                     "Return a JSON array of objects with 'url' and 'title'."

--- a/enkibot/modules/web_tool.py
+++ b/enkibot/modules/web_tool.py
@@ -49,9 +49,8 @@ def web_research(query: str, k: int = 5) -> List[Dict[str, str]]:
     try:
         resp = client.responses.create(
             model=config.OPENAI_DEEP_RESEARCH_MODEL_ID,
-            tools=[{"type": "web_search_preview"}],
+            tools=[{"type": "web_search"}],
             tool_choice="auto",
-            reasoning={"effort": "medium"},
             instructions=(
                 f"Return up to {k} sources as a JSON array of objects with 'title' and 'url'."
             ),


### PR DESCRIPTION
## Summary
- replace deprecated `web_search_preview` tool with `web_search`
- drop unsupported `reasoning` parameter from OpenAI calls

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'telegram'; ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_689a306b58f8832a844cebb978a6e2dc