### PR TITLE
Fix OpenAI web search configuration for fact checking

### DIFF
--- a/enkibot/core/llm_services.py
+++ b/enkibot/core/llm_services.py
@@ -165,8 +165,9 @@ class LLMServices:
             response = await self.openai_async_client.responses.create(
                 model=self.openai_deep_research_model_id,
                 input=messages,
-                tools=[{"type": "web_search"}],
-                tool_choice="auto",
+                tools=[{"type": "web_search_preview"}],
+                tool_choice={"type": "web_search_preview"},
+                reasoning={"effort": "medium"},
                 max_output_tokens=max_output_tokens,
             )
             latency = time.perf_counter() - start

--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -216,8 +216,9 @@ class OpenAIWebFetcher(Fetcher):
                 kwargs["extra_body"] = extra_body
             resp = await client.responses.create(
                 model=config.OPENAI_DEEP_RESEARCH_MODEL_ID,
-                tools=[{"type": "web_search"}],
-                tool_choice={"type": "web_search"},
+                tools=[{"type": "web_search_preview"}],
+                tool_choice={"type": "web_search_preview"},
+                reasoning={"effort": "medium"},
                 instructions="Return 3-6 sources as a JSON array with 'url' and 'title'.",
                 input=claim.text_norm,
                 **kwargs,
@@ -236,8 +237,9 @@ class OpenAIWebFetcher(Fetcher):
             try:
                 resp = await client.responses.create(
                     model=config.OPENAI_MODEL_ID,
-                    tools=[{"type": "web_search"}],
-                    tool_choice={"type": "web_search"},
+                    tools=[{"type": "web_search_preview"}],
+                    tool_choice={"type": "web_search_preview"},
+                    reasoning={"effort": "medium"},
                     instructions="Return 3-6 sources as a JSON array with 'url' and 'title'.",
                     input=claim.text_norm,
                     **kwargs,

--- a/enkibot/modules/primary_source_hunter.py
+++ b/enkibot/modules/primary_source_hunter.py
@@ -107,8 +107,9 @@ class PrimarySourceHunter:
         try:
             resp = await self.client.responses.create(
                 model=self.model_id,
-                tools=[{"type": "web_search"}],
-                tool_choice="auto",
+                tools=[{"type": "web_search_preview"}],
+                tool_choice={"type": "web_search_preview"},
+                reasoning={"effort": "high"},
                 instructions=(
                     "You are a primary-source hunter. Always include 3-6 sources (at least 1 primary). "
                     "Return a JSON array of objects with 'url' and 'title'."

--- a/enkibot/modules/web_tool.py
+++ b/enkibot/modules/web_tool.py
@@ -49,8 +49,9 @@ def web_research(query: str, k: int = 5) -> List[Dict[str, str]]:
     try:
         resp = client.responses.create(
             model=config.OPENAI_DEEP_RESEARCH_MODEL_ID,
-            tools=[{"type": "web_search"}],
-            tool_choice="auto",
+            tools=[{"type": "web_search_preview"}],
+            tool_choice={"type": "web_search_preview"},
+            reasoning={"effort": "medium"},
             instructions=(
                 f"Return up to {k} sources as a JSON array of objects with 'title' and 'url'."
             ),


### PR DESCRIPTION
## Summary
- ensure OpenAI deep research calls include the `web_search_preview` tool with forced usage
- update fact checking, primary source hunter, and web research helpers to use `web_search_preview`

## Testing
- `pytest` *(fails: tests/test_fact_check_claim_lang.py::test_extract_claim_detects_russian)*

------
https://chatgpt.com/codex/tasks/task_e_689a3ce0c290832a86f2ecf610a163bc