### PR TITLE
Fix OpenAI web_search integration and defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ The project is organized into logical modules:
     # LLM API Keys & Models (provide at least OpenAI or one other)
     ENKI_BOT_OPENAI_API_KEY="sk-YOUR_OPENAI_KEY"
     ENKI_BOT_OPENAI_MODEL_ID="gpt-4.1-mini"
-    ENKI_BOT_OPENAI_DEEP_RESEARCH_MODEL_ID="o3-deep-research"  # or o4-mini if you lack access
+    ENKI_BOT_OPENAI_DEEP_RESEARCH_MODEL_ID="gpt-4o-mini"  # or o3-deep-research if you have access
     ENKI_BOT_OPENAI_EMBEDDING_MODEL_ID="text-embedding-3-large"
     ENKI_BOT_OPENAI_MULTIMODAL_IMAGE_MODEL_ID="gpt-4o"
     ENKI_BOT_OPENAI_SEARCH_USER_LOCATION="{\"country\":\"US\"}"

--- a/enkibot/config.py
+++ b/enkibot/config.py
@@ -117,11 +117,11 @@ DB_CONNECTION_STRING = (
 # OpenAI
 OPENAI_API_KEY = os.getenv('ENKI_BOT_OPENAI_API_KEY')
 OPENAI_MODEL_ID = os.getenv('ENKI_BOT_OPENAI_MODEL_ID', 'gpt-4.1-mini')                 # General orchestrator
-# Default deep-research model. `o3-deep-research` offers the best quality.
-# If you do not have access, override with `o4-mini` or another available model
-# via the environment variable.
+# Default deep‑research model. ``gpt-4o-mini`` works for most accounts with
+# built‑in web search. Override with ``o3-deep-research`` or another supported
+# model via the environment variable if you have access.
 OPENAI_DEEP_RESEARCH_MODEL_ID = os.getenv(
-    'ENKI_BOT_OPENAI_DEEP_RESEARCH_MODEL_ID', 'o3-deep-research'
+    'ENKI_BOT_OPENAI_DEEP_RESEARCH_MODEL_ID', 'gpt-4o-mini'
 )
 OPENAI_EMBEDDING_MODEL_ID = os.getenv('ENKI_BOT_OPENAI_EMBEDDING_MODEL_ID', 'text-embedding-3-large')
 OPENAI_CLASSIFICATION_MODEL_ID = os.getenv('ENKI_BOT_OPENAI_CLASSIFICATION_MODEL_ID', 'gpt-3.5-turbo') # For faster tasks like intent classification

--- a/enkibot/core/llm_services.py
+++ b/enkibot/core/llm_services.py
@@ -165,8 +165,7 @@ class LLMServices:
             response = await self.openai_async_client.responses.create(
                 model=self.openai_deep_research_model_id,
                 input=messages,
-                tools=[{"type": "web_search_preview"}],
-                tool_choice={"type": "web_search_preview"},
+                tools=[{"type": "web_search"}],
                 max_output_tokens=max_output_tokens,
             )
             latency = time.perf_counter() - start


### PR DESCRIPTION
## Summary
- replace deprecated `web_search_preview` usage with current `web_search` tool and JSON response parsing
- set `gpt-4o-mini` as default deep-research model and document it
- remove duplicate `@dataclass` decorator in fact check verdict

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a6533afa4832aa9ab5b14d497ffe2