### PR TITLE
Fix OpenAI web search tool configuration

### DIFF
--- a/enkibot/core/llm_services.py
+++ b/enkibot/core/llm_services.py
@@ -153,7 +153,7 @@ class LLMServices:
                                         max_output_tokens: int = 1000) -> Optional[str]:
         """Call OpenAI's deep research model with web search enabled.
 
-        This uses the Responses API so the model can issue `web_search` tool
+        This uses the Responses API so the model can issue `web_search_preview` tool
         calls when checking claims. It returns the aggregated text response or
         ``None`` if the call fails.
         """
@@ -165,7 +165,8 @@ class LLMServices:
             response = await self.openai_async_client.responses.create(
                 model=self.openai_deep_research_model_id,
                 input=messages,
-                tools=[{"type": "web_search"}],
+                tools=[{"type": "web_search_preview"}],
+                tool_choice={"type": "web_search_preview"},
                 max_output_tokens=max_output_tokens,
             )
             latency = time.perf_counter() - start

--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -214,9 +214,9 @@ class OpenAIWebFetcher(Fetcher):
         try:
             resp = await client.responses.create(
                 model=config.OPENAI_DEEP_RESEARCH_MODEL_ID,
-                tools=[{"type": "web_search"}],
+                tools=[{"type": "web_search_preview"}],
+                tool_choice={"type": "web_search_preview"},
                 instructions="Return ONLY a JSON array named 'items' of objects {url, title}.",
-                response_format={"type": "json_object"},
                 input=claim.text_norm,
                 **extra,
             )
@@ -236,9 +236,9 @@ class OpenAIWebFetcher(Fetcher):
             try:
                 resp = await client.responses.create(
                     model=config.OPENAI_MODEL_ID,
-                    tools=[{"type": "web_search"}],
+                    tools=[{"type": "web_search_preview"}],
+                    tool_choice={"type": "web_search_preview"},
                     instructions="Return ONLY a JSON array named 'items' of objects {url, title}.",
-                    response_format={"type": "json_object"},
                     input=claim.text_norm,
                     **extra,
                 )


### PR DESCRIPTION
## Summary
- Use `web_search_preview` tool in fact checking and deep research calls
- Remove unsupported `response_format` argument and force tool usage with `tool_choice`

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a787c90d8832ab289a63228cd8af0