### PR TITLE
Add requirements file and clarify telegram dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,21 +118,11 @@ The project is organized into logical modules:
     ```
 
 3.  **Install dependencies:**
-    Create a `requirements.txt` file in the project root:
-    ```txt
-    python-telegram-bot>=20.0
-    openai>=1.0
-    pyodbc
-    httpx>=0.20
-    langdetect
-    pymorphy3
-    transliterate
-    python-dotenv
-    ```
-    Then install:
+    The project now includes a `requirements.txt` file with the necessary packages. Install them with:
     ```bash
     pip install -r requirements.txt
     ```
+    **Note:** The correct Telegram library is `python-telegram-bot`. If you previously installed the similarly named `telegram` package, uninstall it first to avoid import errors.
 
     If you plan to run the local two-tier models you also need:
     ```txt

--- a/enkibot/README.md
+++ b/enkibot/README.md
@@ -96,21 +96,11 @@ The project is organized into logical modules:
     ```
 
 3.  **Install dependencies:**
-    Create a `requirements.txt` file in the project root:
-    ```txt
-    python-telegram-bot>=20.0
-    openai>=1.0
-    pyodbc
-    httpx>=0.20
-    langdetect
-    pymorphy3
-    transliterate
-    python-dotenv
-    ```
-    Then install:
+    The repository ships with a ready-made `requirements.txt`. Install dependencies with:
     ```bash
     pip install -r requirements.txt
     ```
+    **Note:** Ensure you install `python-telegram-bot` and not the unrelated `telegram` package to prevent import issues.
 
 4.  **Database Setup:**
     * Ensure your MS SQL Server is running and accessible.

--- a/enkibot/main.py
+++ b/enkibot/main.py
@@ -23,10 +23,18 @@
 # -------------------------------------------------------------------------------
 import os
 import logging
-from typing import Optional 
-from telegram import Update
-from telegram.ext import Application
-from telegram.request import HTTPXRequest
+from typing import Optional
+
+try:
+    from telegram import Update
+    from telegram.ext import Application
+    from telegram.request import HTTPXRequest
+except ImportError as exc:
+    raise ImportError(
+        "EnkiBot requires the 'python-telegram-bot' package. Install it with "
+        "`pip install python-telegram-bot>=20.0` and make sure any conflicting "
+        "`telegram` package is uninstalled."
+    ) from exc
 
 from enkibot import config
 from enkibot.utils.logging_config import setup_logging

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,8 @@
+python-telegram-bot>=20.0
+openai>=1.0
+pyodbc
+httpx>=0.20
+langdetect
+pymorphy3
+transliterate
+python-dotenv


### PR DESCRIPTION
## Summary
- add explicit requirements.txt with core package list
- guard main imports to instruct installing python-telegram-bot instead of the telegram package
- update documentation to reference requirements.txt and warn about telegram package conflict

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a7f6c706c832a9542ba597b962305