### PR TITLE
Sanitize bot messages by removing utm_source

### DIFF
--- a/enkibot/utils/message_utils.py
+++ b/enkibot/utils/message_utils.py
@@ -93,6 +93,7 @@ def clean_output_text(text: str) -> str:
     """Sanitize bot replies by removing tracking parameters and duplicate lines.
 
     - Strips ``utm_source=openai`` from any URLs in *text*.
+    - Removes ``?utm_source=openai`` fragments that appear outside of URLs.
     - Removes consecutive duplicate lines to avoid repeated content.
     """
     if not text:
@@ -102,6 +103,8 @@ def clean_output_text(text: str) -> str:
         return _strip_utm_source(match.group(0))
 
     cleaned = URL_PATTERN.sub(repl, text)
+    # Also drop tracking fragments left as plain text
+    cleaned = re.sub(r"[?&]utm_source=openai", "", cleaned)
 
     deduped_lines: list[str] = []
     prev_line: str | None = None

--- a/tests/test_message_utils.py
+++ b/tests/test_message_utils.py
@@ -1,0 +1,19 @@
+import os
+import sys
+import types
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+
+from enkibot.utils.message_utils import clean_output_text
+
+
+def test_clean_output_text_removes_utm_from_url():
+    text = "Check https://example.com/path?utm_source=openai&x=1"
+    expected = "Check https://example.com/path?x=1"
+    assert clean_output_text(text) == expected
+
+
+def test_clean_output_text_removes_utm_from_plain_text():
+    text = "something?utm_source=openai else"
+    assert clean_output_text(text) == "something else"


### PR DESCRIPTION
## Summary
- Strip `?utm_source=openai` fragments from bot messages, covering both URLs and plain text
- Add unit tests validating URL and text sanitization

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a8c363aa8832a9d562d880cf70d2f