### PR TITLE
Handle empty replies after sanitization

### DIFF
--- a/enkibot/core/intent_handlers/general_handler.py
+++ b/enkibot/core/intent_handlers/general_handler.py
@@ -96,6 +96,10 @@ class GeneralIntentHandler:
                     ),
                 )
                 fact_check_result = clean_output_text(fact_check_result)
+                if not fact_check_result:
+                    fact_check_result = self.language_service.get_response_string(
+                        "analysis_unavailable", "Analysis unavailable."
+                    )
                 for chunk in split_text_into_chunks(fact_check_result):
                     await update.message.reply_text(chunk)
             else:

--- a/enkibot/core/intent_handlers/news_handler.py
+++ b/enkibot/core/intent_handlers/news_handler.py
@@ -98,6 +98,8 @@ class NewsIntentHandler:
                         user_prompt_template=compiler_prompts["user_template"]
                     )
                     compiled_response = clean_output_text(compiled_response)
+                    if not compiled_response:
+                        compiled_response = self.language_service.get_response_string("news_api_data_error")
                     for idx, chunk in enumerate(split_text_into_chunks(compiled_response)):
                         await update.message.reply_text(
                             chunk,

--- a/enkibot/utils/message_utils.py
+++ b/enkibot/utils/message_utils.py
@@ -89,15 +89,17 @@ def _strip_utm_source(url: str) -> str:
     return urlunsplit((parts.scheme, parts.netloc, parts.path, new_query, parts.fragment))
 
 
-def clean_output_text(text: str) -> str:
+def clean_output_text(text: str | None) -> str | None:
     """Sanitize bot replies by removing tracking parameters and duplicate lines.
 
     - Strips ``utm_source=openai`` from any URLs in *text*.
     - Removes ``?utm_source=openai`` fragments that appear outside of URLs.
     - Removes consecutive duplicate lines to avoid repeated content.
+
+    Returns ``None`` if the cleaned text would be empty.
     """
     if not text:
-        return text
+        return None
 
     def repl(match: re.Match[str]) -> str:
         return _strip_utm_source(match.group(0))
@@ -113,4 +115,5 @@ def clean_output_text(text: str) -> str:
             deduped_lines.append(line)
         prev_line = line
 
-    return "\n".join(deduped_lines)
+    cleaned_joined = "\n".join(deduped_lines).strip()
+    return cleaned_joined or None

--- a/tests/test_message_utils.py
+++ b/tests/test_message_utils.py
@@ -17,3 +17,7 @@ def test_clean_output_text_removes_utm_from_url():
 def test_clean_output_text_removes_utm_from_plain_text():
     text = "something?utm_source=openai else"
     assert clean_output_text(text) == "something else"
+
+
+def test_clean_output_text_returns_none_when_empty_after_cleaning():
+    assert clean_output_text("?utm_source=openai") is None


### PR DESCRIPTION
## Summary
- Ensure `clean_output_text` returns `None` when sanitization removes all content
- Fall back to default messages in general and news handlers when cleaned text is empty
- Test that `clean_output_text` yields `None` when only tracking params are present

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a8fff3778832a8a2a7afe2ded377d