### PR TITLE
Sanitize URLs in bot replies

### DIFF
--- a/enkibot/core/intent_handlers/general_handler.py
+++ b/enkibot/core/intent_handlers/general_handler.py
@@ -148,6 +148,7 @@ class GeneralIntentHandler:
         )
         
         if reply:
+            reply = clean_output_text(reply) or reply
             keyboard = InlineKeyboardMarkup(
                 [[
                     InlineKeyboardButton("\U0001F504 Regenerate", callback_data="refine:regenerate"),

--- a/enkibot/utils/message_utils.py
+++ b/enkibot/utils/message_utils.py
@@ -102,7 +102,12 @@ def clean_output_text(text: str | None) -> str | None:
         return None
 
     def repl(match: re.Match[str]) -> str:
-        return _strip_utm_source(match.group(0))
+        url = match.group(0)
+        trailing = ""
+        while url and url[-1] in ").,]":
+            trailing = url[-1] + trailing
+            url = url[:-1]
+        return _strip_utm_source(url) + trailing
 
     cleaned = URL_PATTERN.sub(repl, text)
     # Also drop tracking fragments left as plain text

--- a/tests/test_message_utils.py
+++ b/tests/test_message_utils.py
@@ -21,3 +21,9 @@ def test_clean_output_text_removes_utm_from_plain_text():
 
 def test_clean_output_text_returns_none_when_empty_after_cleaning():
     assert clean_output_text("?utm_source=openai") is None
+
+
+def test_clean_output_text_handles_markdown_links():
+    text = "([tass.ru](https://tass.ru/kultura/24749995?utm_source=openai))"
+    expected = "([tass.ru](https://tass.ru/kultura/24749995))"
+    assert clean_output_text(text) == expected


### PR DESCRIPTION
## Summary
- Strip tracking parameters and trailing punctuation from URLs in bot outputs
- Sanitize general handler replies before sending to users
- Test URL cleaning for Markdown links

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a926c1c28832aa63faf556548147c