### PR TITLE
Auto fact-check forwards from TLGRM news channels

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -22,8 +22,9 @@
 # - Expand unit tests to cover more edge cases.
 # -------------------------------------------------------------------------------
 import logging
+from datetime import timedelta
 from telegram import Update
-from telegram.ext import Application
+from telegram.ext import Application, ContextTypes
 
 from enkibot import config
 from enkibot.utils.database import DatabaseManager
@@ -140,6 +141,15 @@ class EnkiBotApplication:
             language_service=self.language_service,
         )
         self.fact_check_bot.register()
+
+        async def _refresh_news_channels_job(_: ContextTypes.DEFAULT_TYPE) -> None:
+            await self.db_manager.refresh_news_channels()
+
+        self.ptb_application.job_queue.run_repeating(
+            _refresh_news_channels_job,
+            interval=timedelta(days=30),
+            first=0,
+        )
 
         logger.info("EnkiBotApplication initialized all services.")
 

--- a/enkibot/utils/news_channels.py
+++ b/enkibot/utils/news_channels.py
@@ -1,0 +1,50 @@
+# enkibot/utils/news_channels.py
+# EnkiBot: Advanced Multilingual Telegram AI Assistant
+# Copyright (C) 2025 Yael Demedetskaya <yaelkroy@gmail.com>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <https://www.gnu.org/licenses/>.
+"""Utilities for retrieving and parsing Telegram news channel usernames."""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import List
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+NEWS_CHANNELS_URL = "https://tlgrm.ru/channels/news"
+_CHANNEL_PATTERN = re.compile(r"@([A-Za-z0-9_]+)")
+
+
+def extract_channel_usernames(html: str) -> List[str]:
+    """Extract unique channel usernames from *html* content.
+
+    Returned usernames do not include the leading '@'.
+    """
+    return sorted(set(_CHANNEL_PATTERN.findall(html)))
+
+
+async def fetch_channel_usernames() -> List[str]:
+    """Fetch the TLGRM news channel directory and return usernames."""
+    try:
+        async with httpx.AsyncClient(timeout=30.0) as client:
+            resp = await client.get(NEWS_CHANNELS_URL)
+            resp.raise_for_status()
+        return extract_channel_usernames(resp.text)
+    except Exception as exc:  # pragma: no cover - network errors
+        logger.error("Failed to fetch news channels: %s", exc)
+        return []

--- a/tests/test_news_channel_parser.py
+++ b/tests/test_news_channel_parser.py
@@ -1,0 +1,12 @@
+import pytest
+
+from enkibot.utils.news_channels import extract_channel_usernames
+
+
+def test_extract_channel_usernames_deduplicates_and_sorts():
+    html = """
+    <div>@AlphaNews</div>
+    <span>@Beta_updates</span>
+    <p>Duplicate @AlphaNews mention</p>
+    """
+    assert extract_channel_usernames(html) == ["AlphaNews", "Beta_updates"]


### PR DESCRIPTION
## Summary
- Scrape TLGRM news channel directory and store usernames in a new `NewsChannels` table
- Schedule monthly refresh of the channel list and auto-fact-check forwards from these sources
- Add unit test for channel list parser

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a9b4648e0832ab9276bf68009be94