### PR TITLE
Fix news channel parsing and enable JobQueue

### DIFF
--- a/enkibot/utils/news_channels.py
+++ b/enkibot/utils/news_channels.py
@@ -27,7 +27,12 @@ import httpx
 logger = logging.getLogger(__name__)
 
 NEWS_CHANNELS_URL = "https://tlgrm.ru/channels/news"
-_CHANNEL_PATTERN = re.compile(r"@([A-Za-z0-9_]+)")
+
+# Only pick channel usernames from links to tlgrm or tg://resolve to avoid
+# matching image resolution hints like ``@2x`` that appear in the page markup.
+_CHANNEL_PATTERN = re.compile(
+    r'href=["\'](?:https://tlgrm\.ru/channels/@|tg://resolve\?domain=)([A-Za-z0-9_]+)["\']'
+)
 
 
 def extract_channel_usernames(html: str) -> List[str]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot>=20.0
+python-telegram-bot[job-queue]>=20.0
 openai>=1.0
 pyodbc
 httpx>=0.20

--- a/tests/test_news_channel_parser.py
+++ b/tests/test_news_channel_parser.py
@@ -3,10 +3,11 @@ import pytest
 from enkibot.utils.news_channels import extract_channel_usernames
 
 
-def test_extract_channel_usernames_deduplicates_and_sorts():
+def test_extract_channel_usernames_from_links_only_and_sorts():
     html = """
-    <div>@AlphaNews</div>
-    <span>@Beta_updates</span>
-    <p>Duplicate @AlphaNews mention</p>
+    <img src="avatar@2x.jpg">
+    <a href="https://tlgrm.ru/channels/@AlphaNews">Alpha</a>
+    <a href='tg://resolve?domain=Beta_updates'>Beta</a>
+    <a href="https://tlgrm.ru/channels/@AlphaNews">duplicate</a>
     """
     assert extract_channel_usernames(html) == ["AlphaNews", "Beta_updates"]


### PR DESCRIPTION
## Summary
- Only parse channel usernames from tlgrm and tg://resolve links
- Add test to ensure parser ignores image @2x patterns
- Include job queue extra for python-telegram-bot

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aa30f4ee0832a8c87f2286e979baa