### PR TITLE
Parse Telegram channels from multiple pages and schedule monthly refresh

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -22,7 +22,7 @@
 # - Expand unit tests to cover more edge cases.
 # -------------------------------------------------------------------------------
 import logging
-from datetime import timedelta
+from datetime import timedelta, time as dtime
 from telegram import Update
 from telegram.ext import Application, ContextTypes
 
@@ -152,10 +152,11 @@ class EnkiBotApplication:
             self.ptb_application.job_queue.run_once(
                 _refresh_news_channels_job, when=0
             )
-            self.ptb_application.job_queue.run_repeating(
+            # Run the refresh on the first day of each month at midnight.
+            self.ptb_application.job_queue.run_monthly(
                 _refresh_news_channels_job,
-                interval=timedelta(days=30),
-                first=timedelta(days=30),
+                time=dtime(hour=0, minute=0),
+                day=1,
             )
         else:
             logger.warning(

--- a/tests/test_news_channel_parser.py
+++ b/tests/test_news_channel_parser.py
@@ -51,6 +51,53 @@ def test_fetch_channel_usernames_handles_pagination(monkeypatch):
         "httpx",
         types.SimpleNamespace(AsyncClient=DummyAsyncClient),
     )
+    # Limit to a single category to exercise pagination logic
+    monkeypatch.setattr(
+        news_channels,
+        "CHANNEL_CATEGORY_URLS",
+        [news_channels.NEWS_CHANNELS_URL],
+    )
 
     result = asyncio.run(news_channels.fetch_channel_usernames())
     assert result == ["Alpha", "Beta"]
+
+
+def test_fetch_channel_usernames_multiple_categories(monkeypatch):
+    tech_page = '<a href="https://tlgrm.ru/channels/@Tech">Tech</a>'
+    news_page = '<a href="https://tlgrm.ru/channels/@News">News</a>'
+
+    class DummyResponse:
+        def __init__(self, text: str):
+            self.text = text
+            self.status_code = 200
+
+        def raise_for_status(self) -> None:
+            return None
+
+    class DummyAsyncClient:
+        def __init__(self, *args, **kwargs):
+            # First the news page, then technology page
+            self._pages = [news_page, tech_page]
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def get(self, url: str):
+            return DummyResponse(self._pages.pop(0))
+
+    monkeypatch.setattr(
+        news_channels,
+        "httpx",
+        types.SimpleNamespace(AsyncClient=DummyAsyncClient),
+    )
+    monkeypatch.setattr(
+        news_channels,
+        "CHANNEL_CATEGORY_URLS",
+        [news_channels.NEWS_CHANNELS_URL, news_channels.TECH_CHANNELS_URL],
+    )
+
+    result = asyncio.run(news_channels.fetch_channel_usernames())
+    assert result == ["News", "Tech"]


### PR DESCRIPTION
## Summary
- Scrape channel usernames from both TLGRM news and technology directories
- Combine usernames across all configured pages and test parsing of multiple categories
- Schedule monthly refresh of channel list via JobQueue

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689aae966bcc832a811580a089073fa4