### PR TITLE
Fix run_monthly argument name

### DIFF
--- a/enkibot/app.py
+++ b/enkibot/app.py
@@ -155,7 +155,7 @@ class EnkiBotApplication:
             # Run the refresh on the first day of each month at midnight.
             self.ptb_application.job_queue.run_monthly(
                 _refresh_news_channels_job,
-                time=dtime(hour=0, minute=0),
+                when=dtime(hour=0, minute=0),
                 day=1,
             )
         else:


### PR DESCRIPTION
## Summary
- correct JobQueue.run_monthly parameter from `time` to `when`

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ab3b21c10832a97f9cf05a38dfe80