### PR TITLE
Restrict fact checking to channel forwards and cover gate logic with tests

### DIFF
--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -821,6 +821,13 @@ class FactCheckBot:
 
     # Handlers --------------------------------------------------------------
     async def on_forward(self, update: Update, ctx: ContextTypes.DEFAULT_TYPE) -> None:
+        forward_from = getattr(update.effective_message, "forward_from_chat", None)
+        # Only handle messages forwarded from channels. Forwards from users or
+        # anonymous sources are ignored, as the news/book gates are intended for
+        # channel content.
+        if not forward_from:
+            return
+
         text = get_text(update.effective_message) or ""
         if not text and (
             update.effective_message.photo
@@ -829,7 +836,7 @@ class FactCheckBot:
         ):
             # Text-first workflow: only invoke OCR if the forward lacks text
             text = await self._ocr_extract(update.effective_message)
-        forward_from = getattr(update.effective_message, "forward_from_chat", None)
+
         forward_username = (
             forward_from.username.lower()
             if forward_from and getattr(forward_from, "username", None)

--- a/tests/test_fact_check_forward_gate.py
+++ b/tests/test_fact_check_forward_gate.py
@@ -1,0 +1,81 @@
+import os
+import sys
+import types
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+sys.modules.setdefault("pyodbc", types.SimpleNamespace(Connection=object))
+
+from enkibot.modules.fact_check import FactCheckBot
+
+
+def build_bot(db_usernames):
+    app = SimpleNamespace(add_handler=lambda *a, **k: None)
+    fc = SimpleNamespace()
+    db_manager = SimpleNamespace(
+        get_news_channel_usernames=AsyncMock(return_value=db_usernames),
+        log_fact_gate=AsyncMock(),
+    )
+    cfg = lambda _id: {"satire": {"enabled": False}, "auto": {"auto_check_news": True}}
+    bot = FactCheckBot(app=app, fc=fc, cfg_reader=cfg, db_manager=db_manager, language_service=SimpleNamespace(get_response_string=lambda *a, **k: ""))
+    bot._run_check = AsyncMock()
+    return bot
+
+
+def make_update(username, text="sample"):
+    msg = SimpleNamespace(
+        text=text,
+        message_id=1,
+        forward_from_chat=SimpleNamespace(username=username) if username else None,
+        photo=None,
+        video=None,
+        document=None,
+        reply_text=AsyncMock(),
+        set_reaction=AsyncMock(),
+    )
+    update = SimpleNamespace(effective_message=msg, effective_chat=SimpleNamespace(id=123))
+    return update
+
+
+def test_forward_from_known_channel_triggers_news_check():
+    bot = build_bot({"known"})
+    update = make_update("known")
+    ctx = SimpleNamespace()
+    asyncio.run(bot.on_forward(update, ctx))
+    bot._run_check.assert_awaited_once()
+    args, kwargs = bot._run_check.await_args
+    assert kwargs.get("track") == "news"
+
+
+def test_forward_unknown_channel_news_gate_triggers_check(monkeypatch):
+    bot = build_bot(set())
+    bot.news_gate.predict = AsyncMock(return_value=0.8)
+    bot.quote_gate.predict = AsyncMock(return_value=0.1)
+    update = make_update("unknown")
+    ctx = SimpleNamespace()
+    asyncio.run(bot.on_forward(update, ctx))
+    bot._run_check.assert_awaited_once()
+    args, kwargs = bot._run_check.await_args
+    assert kwargs.get("track") == "news"
+
+
+def test_forward_unknown_channel_quote_gate_triggers_check(monkeypatch):
+    bot = build_bot(set())
+    bot.news_gate.predict = AsyncMock(return_value=0.1)
+    bot.quote_gate.predict = AsyncMock(return_value=0.9)
+    update = make_update("unknown")
+    ctx = SimpleNamespace()
+    asyncio.run(bot.on_forward(update, ctx))
+    bot._run_check.assert_awaited_once()
+    args, kwargs = bot._run_check.await_args
+    assert kwargs.get("track") == "book"
+
+
+def test_forward_without_channel_ignored():
+    bot = build_bot(set())
+    update = make_update(None)
+    ctx = SimpleNamespace()
+    asyncio.run(bot.on_forward(update, ctx))
+    bot._run_check.assert_not_called()


### PR DESCRIPTION
## Summary
- Ignore forwards that don't originate from a Telegram channel
- Test that known-channel forwards, AI-detected news, and book quotes trigger fact checks

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689ab8397ce8832abf9d9cd1cb1de40b