### PR TITLE
Normalize channel usernames when matching

### DIFF
--- a/enkibot/modules/fact_check.py
+++ b/enkibot/modules/fact_check.py
@@ -838,13 +838,14 @@ class FactCheckBot:
             text = await self._ocr_extract(update.effective_message)
 
         forward_username = (
-            forward_from.username.lower()
+            forward_from.username.lstrip("@").lower()
             if forward_from and getattr(forward_from, "username", None)
             else None
         )
         if forward_username and self.db_manager:
             try:
-                known_sources = await self.db_manager.get_news_channel_usernames()
+                raw_sources = await self.db_manager.get_news_channel_usernames()
+                known_sources = {name.lstrip("@").lower() for name in raw_sources}
             except Exception:
                 known_sources = set()
             if forward_username in known_sources:

--- a/enkibot/utils/database.py
+++ b/enkibot/utils/database.py
@@ -745,7 +745,7 @@ class DatabaseManager:
                 for name in usernames:
                     cursor.execute(
                         "INSERT INTO NewsChannels (Username, UpdatedAt) VALUES (?, GETDATE())",
-                        name.lower(),
+                        name.strip().lstrip("@").lower(),
                     )
             logger.info("Inserted %d news channels", len(usernames))
             conn.commit()
@@ -768,7 +768,9 @@ class DatabaseManager:
             "SELECT Username FROM NewsChannels",
             fetch_all=True,
         )
-        return {row.Username.lower() for row in rows} if rows else set()
+        return (
+            {row.Username.strip().lstrip("@").lower() for row in rows} if rows else set()
+        )
 
     async def refresh_news_channels(self) -> None:
         logger.info("Refreshing news channel list from remote source")

--- a/tests/test_fact_check_forward_gate.py
+++ b/tests/test_fact_check_forward_gate.py
@@ -49,6 +49,16 @@ def test_forward_from_known_channel_triggers_news_check():
     assert kwargs.get("track") == "news"
 
 
+def test_forward_from_known_channel_with_at_sign_triggers_news_check():
+    bot = build_bot({"@known"})
+    update = make_update("known")
+    ctx = SimpleNamespace()
+    asyncio.run(bot.on_forward(update, ctx))
+    bot._run_check.assert_awaited_once()
+    args, kwargs = bot._run_check.await_args
+    assert kwargs.get("track") == "news"
+
+
 def test_forward_unknown_channel_news_gate_triggers_check(monkeypatch):
     bot = build_bot(set())
     bot.news_gate.predict = AsyncMock(return_value=0.8)


### PR DESCRIPTION
## Summary
- Strip leading `@` and lowercase channel usernames before matching forwarded messages to known news channels
- Sanitize channel username storage and retrieval in the database
- Add regression test for channels stored with `@`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689abbcdcbc0832a9e4c071189bb41ed