### PR TITLE
Log forwarded messages after fact check

### DIFF
--- a/tests/test_fact_check_forward_gate.py
+++ b/tests/test_fact_check_forward_gate.py
@@ -97,8 +97,13 @@ def test_forward_without_channel_ignored():
     bot._run_check.assert_not_called()
 
 
-def test_forward_logs_message():
+def test_forward_logs_message_after_check():
     bot = build_bot({"known"})
+
+    async def ensure_not_logged(*args, **kwargs):
+        assert bot.db_manager.log_chat_message_and_upsert_user.await_count == 0
+
+    bot._run_check = AsyncMock(side_effect=ensure_not_logged)
     update = make_update("known")
     ctx = SimpleNamespace()
     asyncio.run(bot.on_forward(update, ctx))


### PR DESCRIPTION
## Summary
- Delay logging of forwarded messages until after fact checking completes
- Test that forwarded messages are logged only after the fact checker runs

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689e2aec4df4832aa31f5d8eb0efbd87